### PR TITLE
Upgrading selenium-standalone for Firefox 45+ support, adding CLI instances

### DIFF
--- a/packages/boiler-config-base/src/make-cli-config.js
+++ b/packages/boiler-config-base/src/make-cli-config.js
@@ -53,6 +53,16 @@ export default function(opts = {}) {
       alias: 'quick',
       type: 'boolean'
     },
+    // Number of instances to run in parallel (boiler-task-selenium)
+    instances: {
+      type: 'number',
+      default: 1
+    },
+    t: {
+      alias: 'test',
+      type: 'boolean',
+      default: false
+    },
     ...cli
   });
 
@@ -109,4 +119,3 @@ export default function(opts = {}) {
 
   return cliConfig;
 }
-

--- a/packages/boiler-task-browser-sync/src/index.js
+++ b/packages/boiler-task-browser-sync/src/index.js
@@ -4,7 +4,7 @@ import boilerUtils from 'boiler-utils';
 
 export default function(gulp, plugins, config) {
   const {browserSync} = plugins;
-  const {browserSync: bsParent, sources, utils} = config;
+  const {browserSync: bsParent, sources, utils, test} = config;
   const {middleware: parentMiddleware, open: parentOpenFn} = bsParent;
   const {internalHost, devPort, buildDir} = sources;
   const {addbase, logError} = utils;
@@ -72,6 +72,11 @@ export default function(gulp, plugins, config) {
       data = {},
       fn
     } = parentConfig;
+
+    if (test) {
+      //disable when Selenium is running multiple instances
+      Object.assign(data, {ghostMode: false});
+    }
 
     const task = (done) => {
       browserSync(data, () => {

--- a/packages/boiler-task-selenium/package.json
+++ b/packages/boiler-task-selenium/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.0.0",
     "mocha": "^2.4.5",
     "require-hacker": "^2.1.3",
-    "selenium-standalone": "^4.9.1",
+    "selenium-standalone": "^5.1.0",
     "wdio-mocha-framework": "^0.2.12",
     "webdriverio": "^4.0.5"
   }

--- a/packages/boiler-task-selenium/src/install.js
+++ b/packages/boiler-task-selenium/src/install.js
@@ -8,7 +8,7 @@ const config = {
     chrome: {
       // check for more recent versions of chrome driver here:
       // http://chromedriver.storage.googleapis.com/index.html
-      version: '2.20',
+      version: '2.21',
       arch: process.arch,
       baseURL: 'http://chromedriver.storage.googleapis.com'
     }
@@ -28,4 +28,3 @@ export default function(opts, cb) {
   merge(config, opts);
   selenium.install(config, cb);
 }
-

--- a/packages/boiler-task-selenium/src/make-config/index.js
+++ b/packages/boiler-task-selenium/src/make-config/index.js
@@ -5,7 +5,7 @@ import getTask from './get-task';
 import addCaps from './add-capapabilites';
 
 export default function({config, gulp}) {
-  const SELENIUM_VERSION = '2.48.2';
+  const SELENIUM_VERSION = '2.53.0';
   const {
     bsConfig,
     file,

--- a/packages/boiler-task-selenium/src/spawn-process.js
+++ b/packages/boiler-task-selenium/src/spawn-process.js
@@ -18,7 +18,7 @@ export default function(opts, config, cb) {
     runGen: run
   } = boilerUtils;
   const {log, magenta} = buildLogger;
-  const {fn: parentFn, local, utils} = config;
+  const {fn: parentFn, local, utils, instances} = config;
   const {addroot, logError} = utils;
   const {TRAVIS_BRANCH} = process.env;
 
@@ -35,7 +35,8 @@ export default function(opts, config, cb) {
     log(message);
 
     const env = _.merge({}, process.env, {
-      WDIO_CONFIG: JSON.stringify(opt),
+      // TODO: Make a better way to override wdio options dynamically
+      WDIO_CONFIG: JSON.stringify(Object.assign(opt,  {maxInstances: instances})),
       TEST_ENV: JSON.stringify({local})
     });
 

--- a/packages/boiler-task-selenium/src/wdio-config/config.js
+++ b/packages/boiler-task-selenium/src/wdio-config/config.js
@@ -10,6 +10,7 @@ const {browsers, specs} = parseNames(options);
 
 const baseConfig = {
   sync: true,
+  maxInstances: 1,
   coloredLogs: true,
   waitforTimeout: 15000,
   framework: 'mocha',

--- a/src/templates/macros/input.html
+++ b/src/templates/macros/input.html
@@ -1,0 +1,6 @@
+{% macro input(name, type) %}
+  <div>
+    <label for="">{{name}}</label>
+    <input name="{{name}}" type="{{type}}" />
+  </div>
+{% endmacro %}

--- a/src/templates/pages/index.html
+++ b/src/templates/pages/index.html
@@ -9,9 +9,13 @@ userName: "BlEEEEEEEEPPPPP" # test for YFM override of app data
 {% extends layouts('default') %}
 {% import macros('isomorphic-comp') as ext %}
 {% from macros('test') import test as testMacro %}
+{% from macros('input') import input as inputMacro %}
 
 {% block main %}
   <div class="container">
+    {{ inputMacro('givenName', 'text') }}
+    {{ inputMacro('lastName', 'text') }}
+    {{ inputMacro('whatever', 'text') }}
     {{ ext.iso(environment, props, 'data-isomorphic', ['sample','another-sample'], 'wrapper') }}
     {{ testMacro('bloop') }}
   </div>

--- a/test/e2e/desktop/some-desktop-spec.js
+++ b/test/e2e/desktop/some-desktop-spec.js
@@ -14,9 +14,14 @@ describe('Desktop Directory Spec', () => {
     expect(title).to.eq('Build Boiler');
   });
 
-  // True test of synchronous commands!
   it('should get a div from the DOM', () => {
     const elm = client.element('body');
     expect(elm).to.not.be.null;
+  });
+
+  it('should fill in the inputs', () => {
+    ['givenName', 'lastName', 'whatever'].forEach((fieldName) => {
+      client.element(`[name="${fieldName}"]`).setValue(fieldName);
+    });
   });
 });

--- a/test/e2e/desktop/wait-desktop-spec.js
+++ b/test/e2e/desktop/wait-desktop-spec.js
@@ -1,0 +1,21 @@
+import {expect} from 'chai';
+import setup from '../../config/e2e-setup';
+
+describe('Desktop Directory Spec', () => {
+  const client = setup();
+  const url = '/';
+
+  before(() => {
+    return client.url(url);
+  });
+
+  it('should wait for three seconds', () => {
+    client.pause(3000);
+  });
+
+  it('should make sure that all fields are still blank', () => {
+    ['givenName', 'lastName', 'whatever'].forEach((fieldName) => {
+      expect(client.element(`[name="${fieldName}"]`).getValue()).to.equal('');
+    });
+  });
+});

--- a/test/e2e/mobile/some-mobile-spec.js
+++ b/test/e2e/mobile/some-mobile-spec.js
@@ -14,9 +14,9 @@ describe('Mobile Directory Spec', () => {
     expect(title).to.eq('Build Boiler');
   });
 
-  // True test of synchronous commands!
-  it('should get a div from the DOM', () => {
-    const elm = client.element('body');
-    expect(elm).to.not.be.null;
+  it('should fill in the inputs', () => {
+    ['givenName', 'lastName', 'whatever'].forEach((fieldName) => {
+      client.element(`[name="${fieldName}"]`).setValue(fieldName);
+    });
   });
 });

--- a/test/e2e/sample-spec.js
+++ b/test/e2e/sample-spec.js
@@ -14,9 +14,14 @@ describe('#SampleSync not exporting ANY browsers', () => {
     expect(title).to.eq('Build Boiler');
   });
 
-  // True test of synchronous commands!
   it('should get a div from the DOM', () => {
     const elm = client.element('body');
     expect(elm).to.not.be.null;
+  });
+
+  it('should fill in the inputs', () => {
+    ['givenName', 'lastName', 'whatever'].forEach((fieldName) => {
+      client.element(`[name="${fieldName}"]`).setValue(fieldName);
+    });
   });
 });


### PR DESCRIPTION
@dtothefp, would you mind taking a look at this tiny pull request?

This changeset includes three updates:

1. Upgrading to the newest version of selenium-standalone to play nicely with Firefox 45+

2. Adding a CLI argument for specifying the number of maximum allowable parallel instances of test runs (defaults to 1)
I'd like to revisit this with the Nightwatch support task -- I think we might be able to leverage this type of CLI arguments for swapping test capabilities on the fly.  

3. Adding a CLI argument to disable ghost mode (for parallel test runs)

**Manual testing (which is automated testing)**
- `gulp watch --force`; `gulp watch --test`; `gulp selenium --desktop=chrome,firefox --instances 10`


Let me know what you think.  Thanks!