### PR TITLE
Adding script for adding owners to all packages

### DIFF
--- a/scripts/add-owner.sh
+++ b/scripts/add-owner.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cwd=`pwd`
+cd packages/
+for d in $(ls -d *); do npm owner add "$1" "$d"; done
+cd $cwd


### PR DESCRIPTION
@dtothefp Try this out:

`./scripts/add-owner.sh stephenkao`

This just loops over all directories in `packages/` and applies an ownership role for the user.  Not tested yet, but give it a shot!