### PR TITLE
subresource integrity

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,10 @@
   "presets": ["react"],
   "plugins": [
     "add-module-exports",
-    "transform-runtime",
+    ["transform-runtime", {
+      "polyfill": false,
+      "regenerator": false
+    }],
     "transform-es2015-for-of",
     "syntax-object-rest-spread",
     "transform-es2015-parameters",
@@ -12,7 +15,6 @@
     "transform-es2015-spread",
     "transform-es2015-destructuring",
     "transform-es2015-modules-commonjs",
-    "transform-strict-mode",
-    "transform-regenerator"
+    "transform-strict-mode"
   ]
 }

--- a/gulp/config/index.js
+++ b/gulp/config/index.js
@@ -210,6 +210,12 @@ export default {
      */
     includePaths: [],
     /**
+     * Whether to use https://github.com/mikechau/sri-stats-webpack-plugin
+     * to write data for subresource integrity
+     * @param {Boolean|String} string specifies sha
+     */
+    integrity: 'sha256',
+    /**
      * add additional paths to webpack `resolve.modulesDirectories`
      * so that can `require/import` without a relative path
      *

--- a/packages/boiler-addon-webpack-babel/package.json
+++ b/packages/boiler-addon-webpack-babel/package.json
@@ -30,7 +30,7 @@
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-decorators-legacy": "^1.2.0",
     "babel-plugin-transform-runtime": "^6.8.0",
-    "babel-plugin-typecheck": "^3.5.1",
+    "babel-plugin-typecheck": "3.8.0",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",

--- a/packages/boiler-addon-webpack-babel/src/loaders.js
+++ b/packages/boiler-addon-webpack-babel/src/loaders.js
@@ -174,7 +174,10 @@ export default function(config, data) {
       return ex;
     },
     loader: 'babel',
-    query: finalBabelQuery
+    query: {
+      babelrc: false,
+      ...finalBabelQuery
+    }
   });
 
   return {

--- a/packages/boiler-addon-webpack-styles/package.json
+++ b/packages/boiler-addon-webpack-styles/package.json
@@ -32,7 +32,7 @@
     "css-loader": "^0.23.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "lodash": "^4.0.0",
-    "node-sass": "3.4.2",
+    "node-sass": "^3.7.0",
     "postcss": "^5.0.0",
     "postcss-loader": "^0.8.0",
     "postcss-reporter": "^1.0.0",

--- a/packages/boiler-config-assemble/package.json
+++ b/packages/boiler-config-assemble/package.json
@@ -31,6 +31,7 @@
     "boiler-addon-isomorphic-tools": "^2.0.6",
     "boiler-utils": "^2.0.6",
     "fs-extra": "^0.26.4",
+    "globby": "^4.1.0",
     "js-yaml": "^3.6.0",
     "lodash": "^4.0.0",
     "plasma": "^0.9.1"

--- a/packages/boiler-config-assemble/src/parse-assets.js
+++ b/packages/boiler-config-assemble/src/parse-assets.js
@@ -3,6 +3,7 @@ import merge from 'lodash/merge';
 import fsX, {readJsonSync} from 'fs-extra';
 import async from 'async';
 import makeTools from 'boiler-addon-isomorphic-tools';
+import {sync as globSync} from 'globby';
 
 export default function(config, opts = {}) {
   const {environment, sources, utils} = config;
@@ -27,8 +28,21 @@ export default function(config, opts = {}) {
 
   function makeStats(main, global) {
     const {assets: images, ...rest} = global;
+    const integrityGlobs = globSync(
+      addbase(buildDir, '*integrity*.json')
+    );
+    const integrity = integrityGlobs.reduce((acc, fp) => {
+      try {
+        const json = require(fp);
+        Object.assign(acc, json);
+      } catch (err) {
+        return acc;
+      }
 
-    return merge({}, main, rest, {images});
+      return acc;
+    }, {});
+
+    return merge({}, main, rest, {images, integrity});
   }
 
   if (isomorphic) {

--- a/packages/boiler-config-base/src/index.js
+++ b/packages/boiler-config-base/src/index.js
@@ -66,7 +66,7 @@ export default function(boilerConfigFp, opts = {}) {
     }
 
     debug(`Found boiler.config.js with addons ${JSON.stringify(addons)}`);
-    const processedAddons = handleAddons(addons, rootDir);
+    const processedAddons = Array.isArray(addons) ? handleAddons(addons, rootDir) : {};
     clone.addons = processedAddons;
     debug(`Processed addons ${JSON.stringify(processedAddons)}`);
 

--- a/packages/boiler-config-webpack/package.json
+++ b/packages/boiler-config-webpack/package.json
@@ -35,6 +35,7 @@
     "gulp-util": "^3.0.7",
     "lodash": "^4.0.0",
     "source-map-support": "^0.4.0",
+    "sri-stats-webpack-plugin": "^0.7.2",
     "url-loader": "^0.5.6"
   },
   "peerDependencies": {

--- a/packages/boiler-config-webpack/src/plugins.js
+++ b/packages/boiler-config-webpack/src/plugins.js
@@ -1,22 +1,28 @@
 import path from 'path';
 import webpack from 'webpack';
 import boilerUtils from 'boiler-utils';
+import SriStatsPlugin from 'sri-stats-webpack-plugin';
+import isString from 'lodash/isString';
 
 export default function(opts) {
   const {
     provide = {},
     isMainTask,
+    isGlobalTask,
     environment,
     sources,
+    utils,
     toolsPlugin,
     webpackConfig
   } = opts;
   const {callAndReturn} = boilerUtils;
   const callParentFn = callAndReturn(opts);
-  const {scriptDir} = sources;
+  const {buildDir, scriptDir} = sources;
+  const {addbase} = utils;
   const {isDev} = environment;
   const {
     env = {},
+    integrity,
     multipleBundles,
     paths
   } = webpackConfig;
@@ -39,6 +45,20 @@ export default function(opts) {
     new ProvidePlugin(provide),
     toolsPlugin
   ];
+
+  const runIntegrity = !!integrity && !isDev && (isMainTask || isGlobalTask);
+
+  if (runIntegrity) {
+    plugins.push(
+      new SriStatsPlugin({
+        algorithm: isString(integrity) ? integrity : 'sha512',
+        allow: /\.(js|css)$/i,
+        assetKey: 'integrity',
+        saveAs: addbase(buildDir, `subresource-integrity-${isMainTask ? 'main' : 'global'}.json`),
+        write: true
+      })
+    );
+  }
 
   if (isMainTask && multipleBundles) {
     const {CommonsChunkPlugin} = webpack.optimize;

--- a/packages/boiler-core/src/index.js
+++ b/packages/boiler-core/src/index.js
@@ -11,12 +11,16 @@ export default function(gulp, opts = {}) {
   const babel = require('babel-core');
   const {
     gulpTaskname: addTaskName,
+    debug: runDebug,
     buildLogger,
     tryExists
   } = boilerUtils;
+  const debug = runDebug(__filename);
   const {fp: configFp, include} = opts;
   const {log, blue} = buildLogger;
+  debug('[make-base-config: start]');
   const baseConfig = makeConfig(configFp);
+  debug('[make-base-config: end]');
   /**
    * Config from `boiler.config.js`
    */
@@ -30,12 +34,16 @@ export default function(gulp, opts = {}) {
     babelExclude: excludeRe = baseExclude
   } = boilerConfig;
 
+  debug('[get-boiler-deps: start]');
   const boilerData = getBoilerDeps(rootDir, {
     tasks: boilerTasks,
     presets
   });
+  debug('[get-boiler-deps: end]');
   const taskNames = Object.keys(boilerData || {});
+  debug('[get-gulp-plugins: start]');
   const plugins = getGulpPlugins(baseConfig, taskNames);
+  debug('[get-gulp-plugins: end]');
 
   /**
    * Because in `babelrc` it is very hard to use minimatch to
@@ -90,11 +98,15 @@ export default function(gulp, opts = {}) {
    *   - sources/environment/utils/pkg/boilerConfig etc
    * with the parent config hooks from `gulp/config/index.js`
    */
+  debug('[get-task-config: start]');
   const config  = getTaskConfig(baseConfig, parentConfig, {
     tasks: taskNames
   });
+  debug('[get-task-config: end]');
 
+  debug('[get-tasks: start]');
   const tasks = getTasks(gulp, plugins, config, boilerData);
+  debug('[get-tasks: end]');
 
   hook.unmount();
 

--- a/packages/boiler-task-mocha/src/hooks/babel.js
+++ b/packages/boiler-task-mocha/src/hooks/babel.js
@@ -1,6 +1,5 @@
-require('babel-register');
-
 if (!global._babelPolyfill) {
+  require('babel-register');
   require('babel-polyfill');
 }
 

--- a/packages/boiler-task-webpack/src/index.js
+++ b/packages/boiler-task-webpack/src/index.js
@@ -17,7 +17,7 @@ export default function(gulp, plugins, config) {
   const {isDev, isIE, isMaster, asset_path: assetPath, branch} = environment;
   const {middleware: parentMiddleware, hot} = webpackConfig;
   const {getTaskName, addbase, logError} = utils;
-  const {mainBundleName, buildDir, devPort, devHost, hotPort} = sources;
+  const {mainBundleName, globalBundleName, buildDir, devPort, devHost, hotPort} = sources;
   const {gutil} = plugins;
   const {
     runParentFn: callParent,
@@ -28,6 +28,7 @@ export default function(gulp, plugins, config) {
   return (cb) => {
     const taskName = getTaskName(gulp.currentTask);
     const isMainTask = taskName === mainBundleName;
+    const isGlobalTask = taskName === globalBundleName;
     const isServer = taskName === 'server';
     const runHot = isMainTask && !isIE && hot;
 
@@ -40,7 +41,12 @@ export default function(gulp, plugins, config) {
       publicPath = isUndefined(branch) ?  bsPath : assetPath;
     }
 
-    const baseConfig = assign({}, config, {isMainTask, publicPath, taskName});
+    const baseConfig = assign({}, config, {
+      isMainTask,
+      isGlobalTask,
+      publicPath,
+      taskName
+    });
 
     if (isServer) {
       merge(baseConfig, {

--- a/packages/boiler-utils/src/remove-end-slashes.js
+++ b/packages/boiler-utils/src/remove-end-slashes.js
@@ -1,0 +1,11 @@
+/**
+ * Normalize for leading and trailing slashes
+ * @param {String} fp
+ *
+ * @return {String}
+ */
+export default function stripSlashes(fp) {
+  if (fp.length <= 1) return fp;
+
+  return fp.trim().replace(/^\/|\/$/g, '');
+}

--- a/packages/boiler-utils/test/remove-end-slashes-spec.js
+++ b/packages/boiler-utils/test/remove-end-slashes-spec.js
@@ -1,0 +1,21 @@
+import {expect} from 'chai';
+import removeSlashes from '../src/remove-end-slashes';
+
+describe('#removeEndSlashes()', () => {
+  it('should return the original path if it is of length 1', () => {
+    const fp = removeSlashes('/');
+    expect(fp).to.equal('/');
+  });
+
+  it('should remove a leading slash', () => {
+    const fp = removeSlashes('/bleep/bloop/bloosh/what');
+    expect(fp).to.equal('bleep/bloop/bloosh/what');
+  });
+
+  it('should remove leading and trailing slash', () => {
+    const fp = removeSlashes('/bleep/bloop/bloosh/what/');
+    expect(fp).to.equal('bleep/bloop/bloosh/what');
+  });
+});
+
+

--- a/src/templates/layouts/default.html
+++ b/src/templates/layouts/default.html
@@ -6,7 +6,7 @@
     <title>{{title}}</title>
 
     {% get_asset type='pantsuit' %}
-    {% get_asset type='css' %}
+    {% get_asset type='css', integrity=true %}
   </head>
   <body>
     <div class="body">
@@ -21,6 +21,6 @@
       {% build_boiler_globals name='_fluxStore', data=globalStore %}
     {% endif %}
 
-    {% get_asset type='js' %}
+    {% get_asset type='js', integrity=true %}
   </body>
 </html>


### PR DESCRIPTION
#### Description
Add subresource integrity on the `get_asset` template tag

```django
{% get_asset type='js', integrity=true %}
```

Also did some updates to lazy load tasks and update the babel configs to not use the regenerator runtime because I learned `async` functions are polyfilled with `generator` functions which are support in node 4+. No more crazy regenerator `while` loops...yay 😄 

We should double check that everything for testing works fine but I think it uses generators not async functions so we should be all good

#### To Test
- `npm run lerna:bootstrap`
- `gulp watch --release` to rebuild all the files with new compilation options
- `gulp watch` when you view source you won't see any integrity data
-  `gulp build && gulp browser-sync` you should see `integrity` attributes on `link` and `script` tags

```html
    <link rel="stylesheet" href="/css/global-29f65c4bb21eeae1a5b7.css" integrity="sha512-O4220SU0TvpCM5p3vbaNOYoe8pgx5jUoa1T1rpUWo3gDWA6UVTfYkM/1t+a+rxgqqxipHFWDDvd5ViPti9OqKQ==">
<link rel="stylesheet" href="/css/vendors-10a880cfb4f2c1121949.css" integrity="sha512-YAw8DsQMn5EuwKwsIcUImwRd1retw5sclL5z76UOiCVnwW0isTUT9Fl7W2H0lgCa/bufDGCUaABmddIhmg5yUA==">
<link rel="stylesheet" href="/css/pages/main-e9e86a518c0fe369849d.css" integrity="sha512-yogwcogBRw7rqRSad4rsap0fBpteeTwNWqP8YyNUYHWKgJ0EWuxkmy1AWSZ+gDaCskebPBKVDEbc75hcK9rpTQ==">

    <script type="text/javascript" src="/js/vendors-10a880cfb4f2c1121949.js" integrity="sha512-IAFGY6VqjhHEuToFWhM3+FnYiFJc6ADe34TaBnHKU4x5xZz3utfgrG48nSHneXh1Cj2e91T0IeLeAZPhKybNPQ=="></script>
<script type="text/javascript" src="/js/pages/main-e9e86a518c0fe369849d.js" integrity="sha512-7iIgqsN0FMdERXZ+hr+pooJ4eVOfqLlYhUW44NJVZBoSiPe8rfQhBL5IVdq/x0unLmZfKySMonIldQ25Oe3Wqw=="></script>
```