### PR TITLE
Adding 'devUrl' to override bucketBase --> devUrl test URL

### DIFF
--- a/nightwatch.config.js
+++ b/nightwatch.config.js
@@ -1,5 +1,10 @@
 export default {
   specsDir: './test/e2e/nightwatch',
   commandsDir: './test/e2e/nightwatch/commands',
-  runner: 'nightwatch'
+  runner: 'nightwatch',
+  customSettings: {
+    globals: {
+      waitForConditionTimeout: 20000
+    }
+  }
 };

--- a/packages/boiler-task-selenium/src/get-capabilities.js
+++ b/packages/boiler-task-selenium/src/get-capabilities.js
@@ -18,6 +18,7 @@ export default function getCapabilities(config, runnerOptions, forceTunnel) {
   const {environment, sources} = config;
   const {branch, isDevRoot, isMaster} = environment;
   const {devPort, devUrl, internalHost} = sources;
+  const {devUrl: devUrlOverride} = runnerOptions;
 
   const {groupOptions, envOptions, authOptions} = getBrowserStackOptions(config);
 
@@ -38,7 +39,7 @@ export default function getCapabilities(config, runnerOptions, forceTunnel) {
    */
   const protocol = branch ? 'https://' : 'http://';
   if (branch) {
-    const base = `${protocol}${devUrl}`;
+    const base = devUrlOverride ? devUrlOverride : `${protocol}${devUrl}`;
 
     if (isDevRoot || isMaster) {
       baseUrl = base;

--- a/packages/boiler-task-selenium/src/runner/nightwatch/run.js
+++ b/packages/boiler-task-selenium/src/runner/nightwatch/run.js
@@ -13,6 +13,7 @@ import {nightwatchDefaults} from './make-config';
 const {thunk} = boilerUtils;
 export default function runNightwatch({opt, concurrent, config, runnerOptions, tmpDir}) {
   const {specsDir, commandsDir} = runnerOptions;
+  const {customSettings = {}} = runnerOptions;
   // Prepare the temp directory for nightwatch-*.json files
   fs.mkdirsSync(tmpDir);
 
@@ -78,7 +79,7 @@ export default function runNightwatch({opt, concurrent, config, runnerOptions, t
       src_folders: [specsDir],
       custom_commands_path: commandsDir,
       output_folder: false,
-      test_settings: {[target]: testSettings[target]}
+      test_settings: {[target]: Object.assign({}, testSettings[target], customSettings)}
     };
     fs.writeJsonSync(configFp, json);
 


### PR DESCRIPTION
@dtothefp, would you mind taking a look at this?

As discussed, this allows you to override the remote URL for tests.  As an added irrelevant bonus, you can add some extra test settings for Nightwatch in the test configuration file.

Let me know what you think.  Thanks!