### PR TITLE
Updating BrowserStack browser version to latest stable

### DIFF
--- a/packages/boiler-task-karma/src/browser-stack/browsers.js
+++ b/packages/boiler-task-karma/src/browser-stack/browsers.js
@@ -2,30 +2,26 @@ export default {
   bs_firefox_mac: {
     base: 'BrowserStack',
     browser: 'firefox',
-    browser_version: '43.0',
     os: 'OS X',
-    os_version: 'Yosemite'
+    os_version: 'El Capitan'
   },
   bs_ie: {
     base: 'BrowserStack',
     browser: 'ie',
-    browser_version: '11.0',
     os: 'Windows',
     os_version: '8.1'
   },
   bs_chrome_windows: {
     base: 'BrowserStack',
     browser: 'chrome',
-    browser_version: '46.0',
+    browser_version: '51.0',
     os: 'WINDOWS',
     os_version: '8.1'
   },
   bs_safari: {
     base: 'BrowserStack',
     browser: 'safari',
-    browser_version: '8.0',
     os: 'OS X',
-    os_version: 'Yosemite'
+    os_version: 'El Capitan'
   }
 };
-

--- a/packages/boiler-task-selenium/src/browser-stack/browsers.js
+++ b/packages/boiler-task-selenium/src/browser-stack/browsers.js
@@ -3,31 +3,26 @@ export const defaults = ['chrome', 'firefox'];
 export default [
   {
     browserName: 'firefox',
-    browser_version: '43.0',
     os: 'OS X',
-    os_version: 'Yosemite'
+    os_version: 'El Capitan'
   },
   {
     browserName: 'edge',
-    browser_version: '12.0',
     os: 'Windows',
     os_version: '10'
   },
   {
     browserName: 'ie',
-    browser_version: '11.0',
     os: 'Windows',
     os_version: '10'
   },
   {
     browserName: 'chrome',
-    browser_version: '47.0',
     os: 'OS X',
     os_version: 'El Capitan'
   },
   {
     browserName: 'safari',
-    browser_version: '9.0',
     os: 'OS X',
     os_version: 'El Capitan'
   }


### PR DESCRIPTION
This update changes the default desktop browser versions for integration and end-to-end tests to be the latest stable available.  (Omitting `browser_version` from the capabilities defaults to latest stable versions, so that's lovely!)

To test:
1. `gulp watch --test` to disable BrowserSync's ghost mode
2. `gulp karma --desktop`
3. `gulp selenium:tunnel --desktop`