### PR TITLE
Adding branch to Assemble middleware

### DIFF
--- a/packages/boiler-addon-assemble-middleware/src/index.js
+++ b/packages/boiler-addon-assemble-middleware/src/index.js
@@ -18,8 +18,11 @@ export default function(app, opts = {}) {
     middleware = {}
   } = parentConfig;
 
+  // Prepare data for middleware hooks to add more context without mutating config!
+  const middlewareConfig = {config, app};
+
   function callFns(fn, ...rest) {
-    fn.length === 1 ? fn(config).apply(null, rest) : fn.apply(null, rest);
+    fn.length === 1 ? fn(middlewareConfig).apply(null, rest) : fn.apply(null, rest);
   }
 
   const ignore = addonConfig.ignore || opts.ignore || {};

--- a/packages/boiler-addon-assemble-middleware/src/on-load/isomorphic-data.js
+++ b/packages/boiler-addon-assemble-middleware/src/on-load/isomorphic-data.js
@@ -2,21 +2,29 @@ import isPlainObject from 'lodash/isPlainObject';
 import {readJsonSync} from 'fs-extra';
 import Plasma from 'plasma';
 
-export default function(config) {
+/**
+ * @param {Object} middlewareConfig
+ *   @param {Object} middlewareConfig.config
+ *   @param {Object} middlewareConfig.app
+ * @return {Function}
+ */
+export default function(middlewareConfig) {
+  const {config, app} = middlewareConfig;
   const {sources, utils} = config;
   const {
     srcDir,
     scriptDir
   } = sources;
   const {addbase} = utils;
-  const plasma = new Plasma();
+  const branch = app.cache.data.branch || '';
 
+  const plasma = new Plasma();
   plasma.dataLoader('json', (fp) => readJsonSync(fp));
 
   return (file, next) => {
     try {
       const jsonData = plasma.load(
-        addbase(srcDir, scriptDir, '**/*.json'), {namespace: true}
+        addbase(srcDir, branch, scriptDir, '**/*.json'), {namespace: true}
       );
 
       if (isPlainObject(jsonData)) {
@@ -29,4 +37,3 @@ export default function(config) {
     }
   };
 }
-

--- a/packages/boiler-addon-assemble-middleware/src/pre-render/global-data.js
+++ b/packages/boiler-addon-assemble-middleware/src/pre-render/global-data.js
@@ -3,23 +3,30 @@ import {safeLoad} from 'js-yaml';
 import {readFileSync} from 'fs';
 import Plasma from 'plasma';
 
-export default function(config) {
+/**
+ * @param {Object} middlewareConfig
+ *   @param {Object} middlewareConfig.config
+ *   @param {Object} middlewareConfig.app
+ * @return {Function}
+ */
+export default function(middlewareConfig) {
+  const {config, app} = middlewareConfig;
   const {sources, utils} = config;
   const {srcDir} = sources;
   const {addbase} = utils;
-  const plasma = new Plasma();
+  const branch = app.cache.data.branch || '';
 
+  const plasma = new Plasma();
   plasma.dataLoader('yml', function(fp) {
     const ymlStr = readFileSync(fp, 'utf8');
 
     return safeLoad(ymlStr);
   });
 
-
   return (file, next) => {
     try {
       const globalData = plasma.load(
-        addbase(srcDir, 'config', '**/*.yml'),
+        addbase(srcDir, branch, 'config', '**/*.yml'),
         {namespace: () => 'global_data'}
       );
 

--- a/packages/boiler-addon-assemble-middleware/src/pre-render/page-data.js
+++ b/packages/boiler-addon-assemble-middleware/src/pre-render/page-data.js
@@ -8,7 +8,15 @@ import {readFileSync} from 'fs';
 import Plasma from 'plasma';
 import boilerUtils from 'boiler-utils';
 
-export default function(config) {
+
+/**
+ * @param {Object} middlewareConfig
+ *   @param {Object} middlewareConfig.config
+ *   @param {Object} middlewareConfig.app
+ * @return {Function}
+ */
+export default function(middlewareConfig) {
+  const {config, app} = middlewareConfig;
   const {sources, utils} = config;
   const {
     srcDir,
@@ -16,6 +24,8 @@ export default function(config) {
   } = sources;
   const {addbase} = utils;
   const {renameKey} = boilerUtils;
+  const branch = app.cache.data.branch || '';
+
   const plasma = new Plasma();
 
   /**
@@ -54,7 +64,7 @@ export default function(config) {
   return (file, next) => {
     try {
       const pageData = plasma.load(
-        addbase(srcDir, templateDir, '**/*.{json,yml}'),
+        addbase(srcDir, branch, templateDir, '**/*.{json,yml}'),
         {namespace: false}
       );
 


### PR DESCRIPTION
@dtothefp This changeset introduces branches to relative paths for Assemble middleware.  Pretty simple schtuff, just wrapping `config` in an object that also includes `app` for more context.