### PR TITLE
Allowing devUrl to be string or function in test.config.js

### DIFF
--- a/packages/boiler-task-selenium/test/config/make-mock-test-config.js
+++ b/packages/boiler-task-selenium/test/config/make-mock-test-config.js
@@ -1,0 +1,12 @@
+// Libraries
+import merge from 'lodash/merge';
+// Mocks
+import wdioConfig from '../mocks/wdio.config';
+import nightwatchConfig from '../mocks/nightwatch.config';
+
+
+export default function makeMockTestConfig(mixin = {}) {
+  const {runner} = mixin;
+  const baseConfig = runner === 'nightwatch' ? nightwatchConfig : wdioConfig;
+  return merge({}, baseConfig, mixin);
+}

--- a/packages/boiler-task-selenium/test/get-capabilities-spec.js
+++ b/packages/boiler-task-selenium/test/get-capabilities-spec.js
@@ -1,22 +1,28 @@
 // Libraries
+import reduce from 'lodash/reduce';
 import {expect} from 'chai';
 // Helpers
 import makeMockConfig from './config/make-mock-config';
+import makeMockTestConfig from './config/make-mock-test-config';
 import getCapabilities from '../src/get-capabilities';
 
-describe(`#getCapabilities()`, () => {
-  it('should return the correct capabilities for chrome', () => {
-    const config = makeMockConfig({
-      desktop: ['chrome']
-    });
 
-    expect(getCapabilities(config)).to.deep.equals({
+const bsConfig = {
+  BROWSERSTACK_USERNAME: 'blah',
+  BROWSERSTACK_API: '2016',
+  localIdentifier: 'whatever'
+};
+describe(`#getCapabilities()`, () => {
+  it('should return the correct WebdriverIO capabilities for chrome', () => {
+    const runnerOptions = makeMockTestConfig({runner: 'wdio'});
+    const config = makeMockConfig({ desktop: ['chrome'] });
+
+    expect(getCapabilities(config, runnerOptions)).to.deep.equals({
       testEnv: 'local',
       testConfig: [{
         baseUrl: 'http://localhost:8000',
         logLevel: 'silent',
         specs: [
-          'test/e2e/nightwatch/desktop/some-desktop-spec.js',
           'test/e2e/wdio/desktop/some-desktop-spec.js',
           'test/e2e/wdio/desktop/wait-desktop-spec.js',
           'test/e2e/wdio/sample-spec.js',
@@ -29,42 +35,16 @@ describe(`#getCapabilities()`, () => {
     });
   });
 
-  it('should return the correct capabilities for firefox', () => {
-    const config = makeMockConfig({
-      desktop: ['firefox']
-    });
+  it('should return the correct WebdriverIO capabilities for chrome and firefox', () => {
+    const runnerOptions = makeMockTestConfig({runner: 'wdio'});
+    const config = makeMockConfig({ desktop: ['chrome', 'firefox'] });
 
-    expect(getCapabilities(config)).to.deep.equals({
+    expect(getCapabilities(config, runnerOptions)).to.deep.equals({
       testEnv: 'local',
       testConfig: [{
         baseUrl: 'http://localhost:8000',
         logLevel: 'silent',
         specs: [
-          'test/e2e/nightwatch/desktop/some-desktop-spec.js',
-          'test/e2e/wdio/desktop/some-desktop-spec.js',
-          'test/e2e/wdio/desktop/wait-desktop-spec.js',
-          'test/e2e/wdio/sample-spec.js',
-          'test/e2e/wdio/some-dir/some-spec.js'
-        ],
-        capabilities: [{
-          browserName: 'firefox'
-        }]
-      }]
-    });
-  });
-
-  it('should return the correct capabilities for chrome and firefox', () => {
-    const config = makeMockConfig({
-      desktop: ['chrome', 'firefox']
-    });
-
-    expect(getCapabilities(config)).to.deep.equals({
-      testEnv: 'local',
-      testConfig: [{
-        baseUrl: 'http://localhost:8000',
-        logLevel: 'silent',
-        specs: [
-          'test/e2e/nightwatch/desktop/some-desktop-spec.js',
           'test/e2e/wdio/desktop/some-desktop-spec.js',
           'test/e2e/wdio/desktop/wait-desktop-spec.js',
           'test/e2e/wdio/sample-spec.js',
@@ -76,6 +56,150 @@ describe(`#getCapabilities()`, () => {
           browserName: 'firefox'
         }]
       }]
+    });
+  });
+
+  it('should return the correct Nightwatch capabilities for chrome and firefox', () => {
+    const runnerOptions = makeMockTestConfig({runner: 'nightwatch'});
+    const config = makeMockConfig({ desktop: ['chrome', 'firefox'] });
+
+    expect(getCapabilities(config, runnerOptions)).to.deep.equals({
+      testEnv: 'local',
+      testConfig: [{
+        baseUrl: 'http://localhost:8000',
+        logLevel: 'silent',
+        specs: [
+          'test/e2e/nightwatch/desktop/some-desktop-spec.js'
+        ],
+        capabilities: [{
+          browserName: 'chrome'
+        }, {
+          browserName: 'firefox'
+        }]
+      }]
+    });
+  });
+
+  const mobileVariations = [{
+    browserName: 'iPhone6',
+    browser_version: '8.0',
+    device: 'iPhone 6'
+  }, {
+    browserName: 'iPhone6S',
+    browser_version: '9.0',
+    device: 'iPhone 6S'
+  }, {
+    browserName: 'android',
+    device: 'Samsung Galaxy S5',
+    platform: 'ANDROID'
+  }];
+  const mobileCaps = reduce(mobileVariations, (acc, obj) => {
+    acc.push({
+      'browserstack.debug': 'true',
+      'browserstack.local': 'true',
+      'browserstack.localIdentifier': bsConfig.localIdentifier,
+      build: 'build-boiler',
+      platform: 'MAC',
+      project: 'v1.0.0 [local:e2e]',
+      name: obj.device,
+      ...obj
+    });
+    return acc;
+  }, []);
+
+  it('should return the correct WebdriverIO capabilities for mobile', () => {
+    const runnerOptions = makeMockTestConfig({runner: 'wdio'});
+    const config = makeMockConfig({mobile: ['iphone', 'android'], bsConfig});
+
+    expect(getCapabilities(config, runnerOptions)).to.deep.equals({
+      testEnv: 'tunnel',
+      testConfig: [{
+        baseUrl: 'http://localhost:8000',
+        logLevel: 'silent',
+        specs: [
+          'test/e2e/wdio/mobile/some-mobile-spec.js',
+          'test/e2e/wdio/sample-spec.js',
+          'test/e2e/wdio/some-dir/some-spec.js'
+        ],
+        capabilities: mobileCaps,
+        user: bsConfig.BROWSERSTACK_USERNAME,
+        key: bsConfig.BROWSERSTACK_API,
+        host: 'hub.browserstack.com',
+        port: 80
+      }]
+    });
+  });
+
+  it('should return the correct Nightwatch capabilities for mobile', () => {
+    const runnerOptions = makeMockTestConfig({runner: 'nightwatch'});
+    const config = makeMockConfig({mobile: ['iphone', 'android'], bsConfig});
+
+    expect(getCapabilities(config, runnerOptions)).to.deep.equals({
+      testEnv: 'tunnel',
+      testConfig: [{
+        baseUrl: 'http://localhost:8000',
+        logLevel: 'silent',
+        specs: [
+          'test/e2e/nightwatch/mobile/some-mobile-spec.js'
+        ],
+        capabilities: mobileCaps,
+        user: bsConfig.BROWSERSTACK_USERNAME,
+        key: bsConfig.BROWSERSTACK_API,
+        host: 'hub.browserstack.com',
+        port: 80
+      }]
+    });
+  });
+
+  it(`should use the value of 'devUrl' if it's a string on Travis`, () => {
+    const url = 'http://razzamatazz.biz';
+    const branch = 'whatever-branch';
+    const runnerOptions = makeMockTestConfig({ devUrl: url });
+    const config = makeMockConfig({
+      desktop: ['chrome'],
+      environment: {
+        branch
+      },
+      bsConfig
+    });
+
+    const caps = getCapabilities(config, runnerOptions);
+    caps.testConfig.forEach((cap) => {
+      expect(cap.baseUrl).to.equal('http://razzamatazz.biz/whatever-branch');
+    });
+  });
+
+  it(`should use the return value of 'devUrl' if it's a function locally`, () => {
+    const url = 'http://razzamatazz.biz';
+    const runnerOptions = makeMockTestConfig({
+      devUrl() {
+        return url;
+      }
+    });
+    const config = makeMockConfig({ desktop: ['chrome'] });
+
+    const caps = getCapabilities(config, runnerOptions);
+    caps.testConfig.forEach((cap) => {
+      expect(cap.baseUrl).to.equal('http://razzamatazz.biz');
+    });
+  });
+
+  it(`should use the return value of 'devUrl' if it's a function on Travis`, () => {
+    const url = 'http://razzamatazz.biz';
+    const branch = 'whatever-branch';
+    const runnerOptions = makeMockTestConfig({
+      devUrl() {
+        return url;
+      },
+      environment: {
+        branch
+      },
+    });
+    const config = makeMockConfig({ desktop: ['chrome'] });
+
+    const caps = getCapabilities(config, runnerOptions);
+    caps.testConfig.forEach((cap) => {
+      expect(cap.baseUrl).to.equal('http://razzamatazz.biz');
     });
   });
 });

--- a/packages/boiler-task-selenium/test/get-test-config-spec.js
+++ b/packages/boiler-task-selenium/test/get-test-config-spec.js
@@ -1,56 +1,12 @@
-
 // Libraries
 import {expect} from 'chai';
+// Mocks
+// Mocks
+import wdioConfig from './mocks/wdio.config';
+import nightwatchConfig from './mocks/nightwatch.config';
 // Helpers
 import getTestConfig from '../src/get-test-config';
-import SpecReporter from '../src/runner/webdriverio/reporters/spec';
 
-
-const nightwatchConfig = {
-  customSettings: {
-    globals: {
-      waitForConditionTimeout: 20000
-    }
-  },
-  globals: {
-    waitForConditionTimeout: 10000
-  },
-  output_folder: false,
-  selenium_port: 4444,
-  selenium_host: 'localhost',
-  silent: true,
-  screenshots: {
-    enabled: false,
-    path: ''
-  },
-  launch_url: '/',
-  desiredCapabilities: {
-    javascriptEnabled: true,
-    acceptSslCerts: true
-  },
-  specsDir: './test/e2e/nightwatch',
-  commandsDir: './test/e2e/nightwatch/commands',
-  runner: 'nightwatch'
-};
-
-const wdioConfig = {
-  specsDir: './test/e2e/wdio',
-  commandsDir: './test/e2e/wdio/commands',
-  runner: 'wdio',
-  sync: true,
-  maxInstances: 1,
-  coloredLogs: true,
-  waitforTimeout: 30000,
-  framework: 'mocha',
-  reporters: [SpecReporter],
-  reporterOptions: {
-    outputDir: './'
-  },
-  mochaOpts: {
-    ui: 'bdd',
-    timeout: 60000
-  }
-};
 
 describe('#getTestConfig()', () => {
   it(`should return the WebdriverIO configuration from test.config.js if none is specified`, () => {

--- a/packages/boiler-task-selenium/test/mocks/nightwatch.config.js
+++ b/packages/boiler-task-selenium/test/mocks/nightwatch.config.js
@@ -1,0 +1,26 @@
+export default {
+  customSettings: {
+    globals: {
+      waitForConditionTimeout: 20000
+    }
+  },
+  globals: {
+    waitForConditionTimeout: 10000
+  },
+  output_folder: false,
+  selenium_port: 4444,
+  selenium_host: 'localhost',
+  silent: true,
+  screenshots: {
+    enabled: false,
+    path: ''
+  },
+  launch_url: '/',
+  desiredCapabilities: {
+    javascriptEnabled: true,
+    acceptSslCerts: true
+  },
+  specsDir: './test/e2e/nightwatch',
+  commandsDir: './test/e2e/nightwatch/commands',
+  runner: 'nightwatch'
+};

--- a/packages/boiler-task-selenium/test/mocks/wdio.config.js
+++ b/packages/boiler-task-selenium/test/mocks/wdio.config.js
@@ -1,0 +1,22 @@
+// Helpers
+import SpecReporter from '../../src/runner/webdriverio/reporters/spec';
+
+
+export default {
+  specsDir: './test/e2e/wdio',
+  commandsDir: './test/e2e/wdio/commands',
+  runner: 'wdio',
+  sync: true,
+  maxInstances: 1,
+  coloredLogs: true,
+  waitforTimeout: 30000,
+  framework: 'mocha',
+  reporters: [SpecReporter],
+  reporterOptions: {
+    outputDir: './'
+  },
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000
+  }
+};


### PR DESCRIPTION
This changeset allows the `devUrl` to be a string or a function. To test this out, you can change `devUrl` in test.config.js to a string-returning function and make sure `gulp selenium --desktop=chrome` opens up the expected url.  Additionally, you can change `devUrl` to a string and `export TRAVIS_BRANCH=whatever` to make sure the branch concatenation is intact.

Let me know what you think.  Thanks!