### PR TITLE
Fixing browser options from CLI and spec file exports

### DIFF
--- a/packages/boiler-task-selenium/test/get-capabilities-spec.js
+++ b/packages/boiler-task-selenium/test/get-capabilities-spec.js
@@ -23,6 +23,7 @@ describe(`#getCapabilities()`, () => {
         baseUrl: 'http://localhost:8000',
         logLevel: 'silent',
         specs: [
+          'test/e2e/wdio/desktop/all-browsers-spec.js',
           'test/e2e/wdio/desktop/some-desktop-spec.js',
           'test/e2e/wdio/desktop/wait-desktop-spec.js',
           'test/e2e/wdio/sample-spec.js',
@@ -45,6 +46,7 @@ describe(`#getCapabilities()`, () => {
         baseUrl: 'http://localhost:8000',
         logLevel: 'silent',
         specs: [
+          'test/e2e/wdio/desktop/all-browsers-spec.js',
           'test/e2e/wdio/desktop/some-desktop-spec.js',
           'test/e2e/wdio/desktop/wait-desktop-spec.js',
           'test/e2e/wdio/sample-spec.js',

--- a/packages/boiler-task-selenium/test/get-test-files-spec.js
+++ b/packages/boiler-task-selenium/test/get-test-files-spec.js
@@ -1,0 +1,120 @@
+// Libraries
+import Immutable from 'immutable';
+import {expect} from 'chai';
+// Helpers
+import makeMockConfig from './config/make-mock-config';
+import getTestFiles, {makeSpecsGlob} from '../src/get-test-files';
+
+
+const baseSpecDir = 'test/e2e/wdio';
+const runnerOptions = { specsDir: baseSpecDir };
+describe(`#makeSpecsGlob`, () => {
+  it(`should return a generic spec glob if both 'desktop' and 'mobile' are specified`, () => {
+    const config = makeMockConfig({desktop: true, mobile: true});
+    expect(makeSpecsGlob(config, runnerOptions)).to.equal(`${baseSpecDir}/**/*-spec.js`);
+  });
+
+  it(`should return a generic spec glob if neither 'desktop' nor 'mobile' is specified`, () => {
+    const config = makeMockConfig();
+    expect(makeSpecsGlob(config, runnerOptions)).to.equal(`${baseSpecDir}/**/*-spec.js`);
+  });
+
+  it(`should return a desktop spec glob if only 'desktop' is specified`, () => {
+    const config = makeMockConfig({desktop: true});
+    expect(makeSpecsGlob(config, runnerOptions)).to.equal(`${baseSpecDir}/{desktop/**/,,!(mobile)/**/}*-spec.js`);
+  });
+
+  it(`should return a mobile spec glob if only 'mobile' is specified`, () => {
+    const config = makeMockConfig({mobile: true});
+    expect(makeSpecsGlob(config, runnerOptions)).to.equal(`${baseSpecDir}/{mobile/**/,,!(desktop)/**/}*-spec.js`);
+  });
+
+  it(`should return a file-specific glob if a file is specified with no platforms`, () => {
+    const file = 'whatever-spec';
+    const config = makeMockConfig({file});
+    expect(makeSpecsGlob(config, runnerOptions)).to.equal(`${baseSpecDir}/**/${file}.js`);
+  });
+
+  it(`should return a file-specific glob if a file is specified with desktop`, () => {
+    const file = 'whatever-spec';
+    const config = makeMockConfig({file, desktop: true});
+    expect(makeSpecsGlob(config, runnerOptions)).to.equal(`${baseSpecDir}/{desktop/**/,,!(mobile)/**/}${file}.js`);
+  });
+});
+
+
+describe(`#getTestFiles`, () => {
+  function compareMaps(mapA, mapB) {
+    expect(JSON.stringify(mapA.toJSON())).to.equal(JSON.stringify(mapB.toJSON()));
+  }
+
+  function getTests(...tests) {
+    return [].concat.apply(Array.prototype, tests).sort();
+  }
+
+  const generalTests = [
+    'test/e2e/wdio/sample-spec.js',
+    'test/e2e/wdio/some-dir/some-spec.js'
+  ];
+  const desktopTests = generalTests.concat([
+    'test/e2e/wdio/desktop/some-desktop-spec.js',
+    'test/e2e/wdio/desktop/wait-desktop-spec.js',
+  ]).sort();
+  const mobileTests = generalTests.concat([
+    'test/e2e/wdio/mobile/some-mobile-spec.js'
+  ]).sort();
+  const tunnelTests = [
+    'test/e2e/wdio/desktop/all-browsers-spec.js'
+  ];
+
+  it(`should use the exported browsers if they're provided`, () => {
+    const config = makeMockConfig({desktop: true, mobile: true});
+    const suite = getTestFiles(config, runnerOptions);
+    compareMaps(suite, new Map([
+      [['chrome', 'firefox'], getTests(desktopTests, tunnelTests)],
+      [['safari', 'ie'], tunnelTests],
+      [['iphone', 'android'], mobileTests]
+    ]));
+  });
+
+  it(`should use the all desktop browsers if 'desktop' is true`, () => {
+    const config = makeMockConfig({desktop: true});
+    const suite = getTestFiles(config, runnerOptions);
+    compareMaps(suite, new Map([
+      [['chrome', 'firefox'], getTests(desktopTests, tunnelTests)],
+      [['safari', 'ie'], tunnelTests]
+    ]));
+  });
+
+  it(`should use the all mobile browsers if 'mobile' is true`, () => {
+    const config = makeMockConfig({mobile: true});
+    const suite = getTestFiles(config, runnerOptions);
+    compareMaps(suite, new Map([
+      [['iphone', 'android'], mobileTests]
+    ]));
+  });
+
+  it(`should use the specified CLI browsers if 'desktop' is a list of browsers`, () => {
+    const config = makeMockConfig({desktop: ['safari', 'ie']});
+    const suite = getTestFiles(config, runnerOptions);
+    compareMaps(suite, new Map([
+      [['safari', 'ie'], getTests(desktopTests, tunnelTests)],
+    ]));
+  });
+
+  it(`should use the specified CLI browsers if 'mobile' is a list of browsers`, () => {
+    const config = makeMockConfig({mobile: ['iphone']});
+    const suite = getTestFiles(config, runnerOptions);
+    compareMaps(suite, new Map([
+      [['iphone'], mobileTests]
+    ]));
+  });
+
+  it(`should override the exported browsers with CLI browsers`, () => {
+    const config = makeMockConfig({desktop: ['chrome']});
+    const suite = getTestFiles(config, runnerOptions);
+    compareMaps(suite, new Map([
+      [['chrome'], getTests(desktopTests, tunnelTests)]
+    ]));
+  });
+});

--- a/test/e2e/wdio/desktop/all-browsers-spec.js
+++ b/test/e2e/wdio/desktop/all-browsers-spec.js
@@ -1,0 +1,11 @@
+// This test exists solely to to make sure the explicit `export default` works for browsers
+
+export default {
+  desktop: ['chrome', 'firefox', 'safari', 'ie']
+};
+
+describe('whatever', () => {
+  it('should verify a tautology', () => {
+    expect(true).to.be.true;
+  });
+});


### PR DESCRIPTION
@dtothefp, mind taking a look?  This addresses [issue 39](https://github.com/dtothefp/build-boiler/issues/39) and adds some checks to make sure the browser option functionality stays intact.

**Automated testing**
- `gulp mocha`
- Added get-test-files-spec.js to verify `makeSpecsGlob` and `getTestFiles`

Let me know what you think.  Thanks!