### PR TITLE
Adding 'glob' option to Assemble middleware to filter data files

### DIFF
--- a/packages/boiler-addon-assemble-middleware/src/index.js
+++ b/packages/boiler-addon-assemble-middleware/src/index.js
@@ -1,8 +1,11 @@
+// Libraries
 import camelCase from 'lodash/camelCase';
 import isBoolean from 'lodash/isBoolean';
 import isFunction from 'lodash/isFunction';
 import path from 'path';
+// Packages
 import boilerUtils from 'boiler-utils';
+
 
 export default function(app, opts = {}) {
   const {
@@ -17,15 +20,15 @@ export default function(app, opts = {}) {
   const {
     middleware = {}
   } = parentConfig;
+  // NOTE: This default glob is repeated in pre-render/global-data.js and pre-render/page-data.js (for easier testing :/)
+  const {glob = '**/*.yml', ignore = opts.ignore || {}} = addonConfig;
 
   // Prepare data for middleware hooks to add more context without mutating config!
-  const middlewareConfig = {config, app};
+  const middlewareConfig = {config, app, glob};
 
   function callFns(fn, ...rest) {
     fn.length === 1 ? fn(middlewareConfig).apply(null, rest) : fn.apply(null, rest);
   }
-
-  const ignore = addonConfig.ignore || opts.ignore || {};
 
   const hooks = [
     'on-load',
@@ -55,6 +58,5 @@ export default function(app, opts = {}) {
         callFns(fn, file, next);
       });
     });
-
   });
 }

--- a/packages/boiler-addon-assemble-middleware/src/pre-render/global-data.js
+++ b/packages/boiler-addon-assemble-middleware/src/pre-render/global-data.js
@@ -1,16 +1,20 @@
+// Libraries
 import isPlainObject from 'lodash/isPlainObject';
 import {safeLoad} from 'js-yaml';
 import {readFileSync} from 'fs';
 import Plasma from 'plasma';
 
+
 /**
  * @param {Object} middlewareConfig
  *   @param {Object} middlewareConfig.config
  *   @param {Object} middlewareConfig.app
+ *   @param {String} middlewareConfig.glob // Optional glob for retrieving data files
  * @return {Function}
  */
-export default function(middlewareConfig) {
-  const {config, app} = middlewareConfig;
+export default function getGlobalDataFn(middlewareConfig) {
+  // NOTE: This default glob is repeated in index.js and page-data.js (for easier testing :/)
+  const {config, app, glob = '**/*.yml'} = middlewareConfig;
   const {sources, utils} = config;
   const {srcDir} = sources;
   const {addbase} = utils;
@@ -26,7 +30,7 @@ export default function(middlewareConfig) {
   return (file, next) => {
     try {
       const globalData = plasma.load(
-        addbase(srcDir, branch, 'config', '**/*.yml'),
+        addbase(srcDir, branch, 'config', glob),
         {namespace: () => 'global_data'}
       );
 

--- a/packages/boiler-addon-assemble-middleware/src/pre-render/page-data.js
+++ b/packages/boiler-addon-assemble-middleware/src/pre-render/page-data.js
@@ -1,3 +1,4 @@
+// Libraries
 import isPlainObject from 'lodash/isPlainObject';
 import merge from 'lodash/merge';
 import path from 'path';
@@ -6,6 +7,7 @@ import {readJsonSync} from 'fs-extra';
 import {safeLoad} from 'js-yaml';
 import {readFileSync} from 'fs';
 import Plasma from 'plasma';
+// Packages
 import boilerUtils from 'boiler-utils';
 
 
@@ -13,10 +15,12 @@ import boilerUtils from 'boiler-utils';
  * @param {Object} middlewareConfig
  *   @param {Object} middlewareConfig.config
  *   @param {Object} middlewareConfig.app
+ *   @param {String} middlewareConfig.glob // Optional glob for retrieving data files
  * @return {Function}
  */
-export default function(middlewareConfig) {
-  const {config, app} = middlewareConfig;
+export default function getPageDataFn(middlewareConfig) {
+  // NOTE: This default glob is repeated in index.js and global-data.js (for easier testing :/)
+  const {config, app, glob = '**/*.yml'} = middlewareConfig;
   const {sources, utils} = config;
   const {
     srcDir,
@@ -64,7 +68,7 @@ export default function(middlewareConfig) {
   return (file, next) => {
     try {
       const pageData = plasma.load(
-        addbase(srcDir, branch, templateDir, '**/*.{json,yml}'),
+        addbase(srcDir, branch, templateDir, glob),
         {namespace: false}
       );
 

--- a/packages/boiler-addon-assemble-middleware/test/pre-render/global-data-spec.js
+++ b/packages/boiler-addon-assemble-middleware/test/pre-render/global-data-spec.js
@@ -1,0 +1,51 @@
+// Libraries
+import {expect} from 'chai';
+import sinon from 'sinon';
+// Mocks
+import makeMockConfig from '../../../../test/config/make-mock-config';
+// Helpers
+import getGlobalDataFn from '../../src/pre-render/global-data';
+
+
+describe(`#getGlobalDataFn`, () => {
+  const config = makeMockConfig();
+  const mockFile = { data: {} };
+
+  it(`should merge data from all files if no glob is specified`, () => {
+    const middlewareConfig = {
+      config,
+      app: { cache: { data: {} } }
+    };
+    const globalDataFn = getGlobalDataFn(middlewareConfig);
+    globalDataFn(mockFile, (error, file) => {
+      expect(file).to.deep.equals({
+        data: {
+          global_data: {
+            some_global_stuff: 'bloop',
+            es_key: 'español',
+            en_key: 'english'
+          }
+        }
+      });
+    });
+  });
+
+  it(`should merge data from specified files if a glob is provided`, () => {
+    const middlewareConfig = {
+      config,
+      app: { cache: { data: {} } },
+      glob: '**/!(es-)*.yml'
+    };
+    const globalDataFn = getGlobalDataFn(middlewareConfig);
+    globalDataFn(mockFile, (error, file) => {
+      expect(file).to.deep.equals({
+        data: {
+          global_data: {
+            some_global_stuff: 'bloop',
+            en_key: 'english'
+          }
+        }
+      });
+    });
+  });
+});

--- a/packages/boiler-addon-assemble-middleware/test/pre-render/page-data-spec.js
+++ b/packages/boiler-addon-assemble-middleware/test/pre-render/page-data-spec.js
@@ -1,0 +1,56 @@
+// Libraries
+import merge from 'lodash/merge';
+import {expect} from 'chai';
+import sinon from 'sinon';
+// Mocks
+import makeMockConfig from '../../../../test/config/make-mock-config';
+// Helpers
+import getPageDataFn from '../../src/pre-render/page-data';
+
+
+describe(`#getPageDataFn`, () => {
+  const config = makeMockConfig();
+  const mockFile = {
+    key: 'pages/index',
+    data: {}
+  };
+
+  it(`should merge data from all local files if no glob is specified`, () => {
+    const middlewareConfig = {
+      config,
+      app: { cache: { data: {} } }
+    };
+    const pageDataFn = getPageDataFn(middlewareConfig);
+
+    pageDataFn(mockFile, (error, file) => {
+      expect(file).to.deep.equals(merge({}, mockFile, {
+        data: {
+          page_data: {
+            some_local_stuff: 'Stuff from src/templates/pages/local.yml',
+            es_key: 'español',
+            en_key: 'english'
+          }
+        }
+      }));
+    });
+  });
+
+  it(`should merge data from specified local files if a glob is provided`, () => {
+    const middlewareConfig = {
+      config,
+      app: { cache: { data: {} } },
+      glob: '**/!(es-)*.yml'
+    };
+    const pageDataFn = getPageDataFn(middlewareConfig);
+    pageDataFn(mockFile, (error, file) => {
+      expect(file).to.deep.equals(merge({}, mockFile, {
+        data: {
+          page_data: {
+            some_local_stuff: 'Stuff from src/templates/pages/local.yml',
+            en_key: 'english'
+          }
+        }
+      }));
+    });
+  });
+});

--- a/packages/boiler-task-selenium/test/get-capabilities-spec.js
+++ b/packages/boiler-task-selenium/test/get-capabilities-spec.js
@@ -2,7 +2,7 @@
 import reduce from 'lodash/reduce';
 import {expect} from 'chai';
 // Helpers
-import makeMockConfig from './config/make-mock-config';
+import makeMockConfig from '../../../test/config/make-mock-config';
 import makeMockTestConfig from './config/make-mock-test-config';
 import getCapabilities from '../src/get-capabilities';
 

--- a/src/config/es-global.yml
+++ b/src/config/es-global.yml
@@ -1,0 +1,2 @@
+some_global_stuff: "bloop en español"
+es_key: "español"

--- a/src/config/global.yml
+++ b/src/config/global.yml
@@ -1,1 +1,2 @@
 some_global_stuff: "bloop"
+en_key: "english"

--- a/src/templates/pages/es-local.yml
+++ b/src/templates/pages/es-local.yml
@@ -1,0 +1,2 @@
+some_local_stuff: "Stuff from src/templates/pages/es-local.yml"
+es_key: "español"

--- a/src/templates/pages/local.yml
+++ b/src/templates/pages/local.yml
@@ -1,1 +1,2 @@
 some_local_stuff: "Stuff from src/templates/pages/local.yml"
+en_key: "english"

--- a/test/config/make-mock-config.js
+++ b/test/config/make-mock-config.js
@@ -1,7 +1,9 @@
 // Libraries
 import path from 'path';
 import merge from 'lodash/merge';
-import makeConfig from '../../../boiler-config-base/src/index';
+// Mocks
+import makeConfig from '../../packages/boiler-config-base/src/index';
+
 
 export default function(mixin = {}) {
   const mockPath = path.resolve(__dirname, '..', 'mocks');


### PR DESCRIPTION
Hey, @dtothefp -- could you take a look at this?

This changeset just includes adding a `glob` option to the addon configuration to filter through data files in the Assemble middleware.  I've added some cursory tests to verify the tail end of the process, but we could add some more tests if we want to be more thorough. 💃 

Also, I pulled out the make-mock-config.js file into the top-level since it could be useful for unit/integration testing other packages.  Let me know what you think.  Thanks!