### PR TITLE
Locking selenium-standalone to 5.1.0

### DIFF
--- a/packages/boiler-task-selenium/package.json
+++ b/packages/boiler-task-selenium/package.json
@@ -36,7 +36,7 @@
     "mocha": "^2.4.5",
     "nightwatch": "^0.9.1",
     "require-hacker": "^2.1.3",
-    "selenium-standalone": "^5.1.0",
+    "selenium-standalone": "5.1.0",
     "wdio-mocha-framework": "^0.2.12",
     "webdriverio": "^4.0.5"
   }


### PR DESCRIPTION
Hey, @dtothefp!  selenium-standalone needs to be locked down to 5.1.0 to prevent assumptions about geckodriver.  We can shrinkwrap this and other package dependencies in the future when we have some more time, but this is breaking peeps' tests right now.  Let me know what you think.  Thanks!

Testing will be the death of us all.