### PR TITLE
Adding Babel dependencies to resolve regenerator/static test failures

### DIFF
--- a/packages/boiler-task-selenium/package.json
+++ b/packages/boiler-task-selenium/package.json
@@ -26,8 +26,14 @@
     "webpack"
   ],
   "dependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-syntax-async-functions": "^6.8.0",
+    "babel-plugin-transform-async-to-generator": "^6.8.0",
+    "babel-plugin-transform-class-properties": "^6.11.5",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-polyfill": "^6.3.14",
+    "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.3.13",
     "boiler-utils": "^3.0.9",
     "browserstacktunnel-wrapper": "^1.4.2",

--- a/packages/boiler-task-selenium/src/runner/webdriverio/index.js
+++ b/packages/boiler-task-selenium/src/runner/webdriverio/index.js
@@ -2,8 +2,15 @@
  * Bootstrap the es6 process here for test files and config
  */
 require('babel-register')({
-  presets: ['es2015', 'stage-0'],
-  plugins: ['add-module-exports'],
+  babelrc: false,
+  presets: [require.resolve('babel-preset-es2015-node4')],
+  plugins: [
+    'add-module-exports',
+    'syntax-async-functions',
+    'transform-async-to-generator',
+    'transform-class-properties',
+    'transform-object-rest-spread'
+  ],
   //tell babel to compile @hfa node_modules
   ignore: /^.+\/node_modules\/(?!@hfa\/).+\.jsx?$/
 });

--- a/test/e2e/wdio/desktop/some-desktop-spec.js
+++ b/test/e2e/wdio/desktop/some-desktop-spec.js
@@ -1,5 +1,17 @@
 import {expect} from 'chai';
 
+// Just here to make sure the Babel class properties can be transformed!
+class Whatever {
+  static whatever = 'puppies';
+}
+
+function wait(delay = 500, counter = 0) {
+  try {
+    return new Promise((res) => setTimeout(res.bind(null, counter += delay), delay));
+  } catch (e) {
+    global.console.log(e);
+  }
+}
 
 describe('Desktop Directory Spec', () => {
   const client = global.browser;
@@ -22,6 +34,13 @@ describe('Desktop Directory Spec', () => {
   it('should fill in the inputs', () => {
     ['givenName', 'lastName', 'whatever'].forEach((fieldName) => {
       client.element(`[name="${fieldName}"]`).setValue(fieldName);
+    });
+  });
+
+  it('should be able to execute an asynchronous function', () => {
+    client.waitUntil(async () => {
+      await wait(5000);
+      return true;
     });
   });
 });


### PR DESCRIPTION
@dtothefp It worked!

I added new Babel plugins and the Node 4 preset to get the tests running.  Also added a new very, very simple end-to-end test to make sure our bases are covered in case of `async` and `static` regressions.

I feel like you've saved my hide one hundred times already this week, and it's only Monday.  :P