### PR TITLE
Adding Snyk policy

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,49 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T00:11:59.571Z'
+      glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T00:11:59.571Z'
+      glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T00:11:59.571Z'
+      glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T00:11:59.571Z'
+      gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T00:11:59.571Z'
+      gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T00:11:59.571Z'
+      gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:55:24.390Z'
+  'npm:tough-cookie:20160722':
+    - glob-watcher > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:55:24.390Z'
+    - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:55:24.390Z'

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ notifications:
 before_install:
   - npm config set progress=false
   - npm install -g npm@^3
+  - npm install -g snyk
 install:
   - npm i
   - 'npm run lerna:bootstrap'
@@ -57,3 +58,4 @@ install:
 script:
   - npm start
   - npm test
+  - ./run-snyk.sh test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "bs": "node ./scripts/install.js && lerna bootstrap",
     "compile": "gulp build --release",
     "publish": "gulp build --release && gulp mocha &&  lerna publish",
-    "publish:all": "gulp build --release && gulp mocha && lerna publish --force-publish=* --yes"
+    "publish:all": "gulp build --release && gulp mocha && lerna publish --force-publish=* --yes",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
   },
   "author": "DtotheFP",
   "license": "Copyright 2016",
@@ -89,6 +91,8 @@
     "webpack": "^1.12.14"
   },
   "dependencies": {
-    "babel-plugin-transform-runtime": "^6.8.0"
-  }
+    "babel-plugin-transform-runtime": "^6.8.0",
+    "snyk": "^1.18.0"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-assemble-isomorphic-memory/.snyk
+++ b/packages/boiler-addon-assemble-isomorphic-memory/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:56:18.009Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:56:18.009Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:56:18.009Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:56:18.009Z'

--- a/packages/boiler-addon-assemble-isomorphic-memory/package.json
+++ b/packages/boiler-addon-assemble-isomorphic-memory/package.json
@@ -33,9 +33,16 @@
     "globby": "^4.0.0",
     "jsdom": "^8.0.4",
     "lodash": "^4.0.0",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-assemble-isomorphic-static/.snyk
+++ b/packages/boiler-addon-assemble-isomorphic-static/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-addon-assemble-isomorphic-static/package.json
+++ b/packages/boiler-addon-assemble-isomorphic-static/package.json
@@ -33,5 +33,11 @@
     "jsdom": "^8.0.4",
     "lodash": "^4.0.0",
     "through2": "^2.0.0"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-addon-assemble-middleware/.snyk
+++ b/packages/boiler-addon-assemble-middleware/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-addon-assemble-middleware/package.json
+++ b/packages/boiler-addon-assemble-middleware/package.json
@@ -32,5 +32,11 @@
     "lodash": "^4.0.0",
     "parser-front-matter": "^1.3.0",
     "plasma": "^0.9.1"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-addon-assemble-nunjucks/.snyk
+++ b/packages/boiler-addon-assemble-nunjucks/.snyk
@@ -1,0 +1,6 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:tough-cookie:20160722':
+    - nunjucks > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:56:38.239Z'

--- a/packages/boiler-addon-assemble-nunjucks/package.json
+++ b/packages/boiler-addon-assemble-nunjucks/package.json
@@ -34,6 +34,13 @@
     "nunjucks": "^2.1.0",
     "react": "15.1.0",
     "react-dom": "15.1.0",
-    "uglify-js": "^2.6.2"
-  }
+    "uglify-js": "^2.6.2",
+    "snyk": "^1.18.0"
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-isomorphic-tools/.snyk
+++ b/packages/boiler-addon-isomorphic-tools/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-addon-isomorphic-tools/package.json
+++ b/packages/boiler-addon-isomorphic-tools/package.json
@@ -29,5 +29,11 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "lodash": "^4.0.0",
     "webpack-isomorphic-tools": "^2.2.14"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-addon-webpack-babel/.snyk
+++ b/packages/boiler-addon-webpack-babel/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:56:48.021Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:56:48.021Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:56:48.021Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:56:48.021Z'

--- a/packages/boiler-addon-webpack-babel/package.json
+++ b/packages/boiler-addon-webpack-babel/package.json
@@ -41,9 +41,16 @@
     "lodash": "^4.0.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
-    "redbox-react": "^1.2.0"
+    "redbox-react": "^1.2.0",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-webpack-isomorphic/.snyk
+++ b/packages/boiler-addon-webpack-isomorphic/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:07.810Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:07.810Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:07.810Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:07.810Z'

--- a/packages/boiler-addon-webpack-isomorphic/package.json
+++ b/packages/boiler-addon-webpack-isomorphic/package.json
@@ -30,9 +30,16 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "boiler-utils": "^3.0.9",
     "globby": "^4.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-webpack-karma/.snyk
+++ b/packages/boiler-addon-webpack-karma/.snyk
@@ -1,0 +1,57 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - isparta-loader > isparta > istanbul > fileset > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - isparta > istanbul > fileset > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:15.873Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:15.873Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:15.873Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:15.873Z'

--- a/packages/boiler-addon-webpack-karma/package.json
+++ b/packages/boiler-addon-webpack-karma/package.json
@@ -32,9 +32,16 @@
     "isparta": "^4.0.0",
     "isparta-loader": "^2.0.0",
     "lodash": "^4.0.0",
-    "uglify-loader": "^1.3.0"
+    "uglify-loader": "^1.3.0",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-webpack-loaders-base/.snyk
+++ b/packages/boiler-addon-webpack-loaders-base/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:24.922Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:24.922Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:24.922Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:24.922Z'

--- a/packages/boiler-addon-webpack-loaders-base/package.json
+++ b/packages/boiler-addon-webpack-loaders-base/package.json
@@ -35,9 +35,16 @@
     "imports-loader": "^0.6.4",
     "json-loader": "^0.5.2",
     "lodash": "^4.0.0",
-    "style-loader": "^0.13.0"
+    "style-loader": "^0.13.0",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-webpack-loaders-optimize/.snyk
+++ b/packages/boiler-addon-webpack-loaders-optimize/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:57:33.921Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:33.921Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:33.921Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:57:33.921Z'

--- a/packages/boiler-addon-webpack-loaders-optimize/package.json
+++ b/packages/boiler-addon-webpack-loaders-optimize/package.json
@@ -30,9 +30,16 @@
     "boiler-utils": "^3.0.9",
     "img-loader": "^1.2.2",
     "lodash": "^4.0.0",
-    "url-loader": "^0.5.6"
+    "url-loader": "^0.5.6",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-addon-webpack-styles/.snyk
+++ b/packages/boiler-addon-webpack-styles/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:58:21.303Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:58:21.303Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:58:21.303Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:58:21.303Z'

--- a/packages/boiler-addon-webpack-styles/package.json
+++ b/packages/boiler-addon-webpack-styles/package.json
@@ -37,9 +37,16 @@
     "postcss-loader": "^0.8.0",
     "postcss-reporter": "^1.0.0",
     "sass-loader": "^3.0.0",
-    "style-loader": "^0.13.0"
+    "style-loader": "^0.13.0",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-config-assemble/.snyk
+++ b/packages/boiler-config-assemble/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-config-assemble/package.json
+++ b/packages/boiler-config-assemble/package.json
@@ -35,5 +35,11 @@
     "js-yaml": "^3.6.0",
     "lodash": "^4.0.0",
     "plasma": "^0.9.1"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-config-base/.snyk
+++ b/packages/boiler-config-base/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-config-base/package.json
+++ b/packages/boiler-config-base/package.json
@@ -32,5 +32,11 @@
     "fs-extra": "^0.26.5",
     "lodash": "^4.0.0",
     "yargs": "^4.1.0"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-config-eslint/.snyk
+++ b/packages/boiler-config-eslint/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-config-eslint/package.json
+++ b/packages/boiler-config-eslint/package.json
@@ -4,7 +4,7 @@
   "description": "Linting Config",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "snyk test",
     "start": "gulp"
   },
   "repository": {
@@ -23,5 +23,8 @@
     "boiler-utils": "^3.0.9",
     "findup-sync": "^0.3.0",
     "object-assign": "^4.0.1"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-config-webpack/.snyk
+++ b/packages/boiler-config-webpack/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T15:58:58.625Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:58:58.625Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:58:58.625Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:58:58.625Z'

--- a/packages/boiler-config-webpack/package.json
+++ b/packages/boiler-config-webpack/package.json
@@ -36,9 +36,16 @@
     "lodash": "^4.0.0",
     "source-map-support": "^0.4.0",
     "sri-stats-webpack-plugin": "^0.7.2",
-    "url-loader": "^0.5.6"
+    "url-loader": "^0.5.6",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-core/.snyk
+++ b/packages/boiler-core/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-core/package.json
+++ b/packages/boiler-core/package.json
@@ -34,5 +34,11 @@
     "lodash": "^4.0.0",
     "require-hacker": "^2.1.3",
     "run-sequence": "^1.1.5"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-preset-base/.snyk
+++ b/packages/boiler-preset-base/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-preset-base/package.json
+++ b/packages/boiler-preset-base/package.json
@@ -33,5 +33,11 @@
     "boiler-task-copy": "^3.0.9",
     "boiler-task-eslint": "^3.0.9",
     "boiler-task-webpack": "^3.0.9"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-preset-plus/.snyk
+++ b/packages/boiler-preset-plus/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-preset-plus/package.json
+++ b/packages/boiler-preset-plus/package.json
@@ -30,5 +30,11 @@
     "boiler-preset-base": "^3.2.0",
     "boiler-task-karma": "^3.1.2",
     "boiler-task-selenium": "^3.2.5"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-task-assemble/.snyk
+++ b/packages/boiler-task-assemble/.snyk
@@ -1,0 +1,6 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:tough-cookie:20160722':
+    - base-watch > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:59:23.803Z'

--- a/packages/boiler-task-assemble/package.json
+++ b/packages/boiler-task-assemble/package.json
@@ -31,6 +31,13 @@
     "boiler-config-assemble": "^3.2.0",
     "boiler-utils": "^3.0.9",
     "gulp-if": "^2.0.0",
-    "lodash": "^4.0.0"
-  }
+    "lodash": "^4.0.0",
+    "snyk": "^1.18.0"
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-task-babel/.snyk
+++ b/packages/boiler-task-babel/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-task-babel/package.json
+++ b/packages/boiler-task-babel/package.json
@@ -37,5 +37,11 @@
     "gulp-newer": "^1.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "lodash": "^4.0.0"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-task-browser-sync/.snyk
+++ b/packages/boiler-task-browser-sync/.snyk
@@ -1,0 +1,37 @@
+version: v1.5.2
+ignore:
+  'npm:connect:20130701':
+    - browser-sync > browser-sync-ui > weinre > express > connect:
+        reason: None given
+        expires: '2016-09-14T16:00:12.911Z'
+  'npm:express:20140912':
+    - browser-sync > browser-sync-ui > weinre > express:
+        reason: None given
+        expires: '2016-09-14T16:00:12.911Z'
+  'npm:qs:20140806':
+    - browser-sync > browser-sync-ui > weinre > express > qs:
+        reason: None given
+        expires: '2016-09-14T16:00:12.911Z'
+  'npm:qs:20140806-1':
+    - browser-sync > browser-sync-ui > weinre > express > qs:
+        reason: None given
+        expires: '2016-09-14T16:00:12.911Z'
+patch:
+  'npm:negotiator:20160616':
+    - browser-sync > socket.io > engine.io > accepts > negotiator:
+        patched: '2016-08-15T15:59:50.169Z'
+    - browser-sync > serve-index > accepts > negotiator:
+        patched: '2016-08-15T15:59:50.169Z'
+  'npm:request:20160119':
+    - browser-sync > localtunnel > request:
+        patched: '2016-08-15T15:59:50.169Z'
+  'npm:tough-cookie:20160722':
+    - browser-sync > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T15:59:50.169Z'
+    - browser-sync > localtunnel > request > tough-cookie:
+        patched: '2016-08-15T15:59:50.169Z'
+  'npm:ws:20160624':
+    - browser-sync > socket.io > engine.io > ws:
+        patched: '2016-08-15T15:59:50.169Z'
+    - browser-sync > socket.io > socket.io-client > engine.io-client > ws:
+        patched: '2016-08-15T15:59:50.169Z'

--- a/packages/boiler-task-browser-sync/package.json
+++ b/packages/boiler-task-browser-sync/package.json
@@ -28,8 +28,15 @@
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.8.0",
     "boiler-utils": "^3.0.9",
-    "browser-sync": "^2.9.8",
+    "browser-sync": "^2.14.0",
     "lodash": "^4.0.0",
-    "open": "0.0.5"
-  }
+    "open": "0.0.5",
+    "snyk": "^1.18.0"
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-task-clean/.snyk
+++ b/packages/boiler-task-clean/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-task-clean/package.json
+++ b/packages/boiler-task-clean/package.json
@@ -29,5 +29,11 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "boiler-utils": "^3.0.9",
     "del": "^2.2.0"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-task-copy/.snyk
+++ b/packages/boiler-task-copy/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-task-copy/package.json
+++ b/packages/boiler-task-copy/package.json
@@ -29,5 +29,11 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "boiler-utils": "^3.0.9",
     "gulp-rename": "^1.2.2"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-task-eslint/.snyk
+++ b/packages/boiler-task-eslint/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-task-eslint/package.json
+++ b/packages/boiler-task-eslint/package.json
@@ -34,5 +34,11 @@
     "eslint-friendly-formatter": "^1.1.0",
     "eslint-plugin-react": "^3.16.1",
     "gulp-eslint": "^1.1.1"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-task-karma/.snyk
+++ b/packages/boiler-task-karma/.snyk
@@ -1,0 +1,48 @@
+version: v1.5.2
+ignore:
+  'npm:connect:20130701':
+    - browser-sync > browser-sync-ui > weinre > express > connect:
+        reason: None given
+        expires: '2016-09-14T16:01:45.663Z'
+  'npm:express:20140912':
+    - browser-sync > browser-sync-ui > weinre > express:
+        reason: None given
+        expires: '2016-09-14T16:01:45.663Z'
+  'npm:qs:20140806':
+    - browser-sync > browser-sync-ui > weinre > express > qs:
+        reason: None given
+        expires: '2016-09-14T16:01:45.663Z'
+  'npm:qs:20140806-1':
+    - browser-sync > browser-sync-ui > weinre > express > qs:
+        reason: None given
+        expires: '2016-09-14T16:01:45.663Z'
+patch:
+  'npm:minimatch:20160620':
+    - karma-coverage > istanbul > fileset > minimatch:
+        patched: '2016-08-15T16:01:15.654Z'
+  'npm:negotiator:20160616':
+    - karma > socket.io > engine.io > accepts > negotiator:
+        patched: '2016-08-15T16:01:15.654Z'
+    - browser-sync > socket.io > engine.io > accepts > negotiator:
+        patched: '2016-08-15T16:01:15.654Z'
+    - browser-sync > serve-index > accepts > negotiator:
+        patched: '2016-08-15T16:01:15.654Z'
+  'npm:request:20160119':
+    - browser-sync > localtunnel > request:
+        patched: '2016-08-15T16:01:15.654Z'
+  'npm:tough-cookie:20160722':
+    - karma > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T16:01:15.654Z'
+    - browser-sync > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T16:01:15.654Z'
+    - browser-sync > localtunnel > request > tough-cookie:
+        patched: '2016-08-15T16:01:15.654Z'
+  'npm:ws:20160624':
+    - karma > socket.io > engine.io > ws:
+        patched: '2016-08-15T16:01:15.654Z'
+    - karma > socket.io > socket.io-client > engine.io-client > ws:
+        patched: '2016-08-15T16:01:15.654Z'
+    - browser-sync > socket.io > engine.io > ws:
+        patched: '2016-08-15T16:01:15.654Z'
+    - browser-sync > socket.io > socket.io-client > engine.io-client > ws:
+        patched: '2016-08-15T16:01:15.654Z'

--- a/packages/boiler-task-karma/package.json
+++ b/packages/boiler-task-karma/package.json
@@ -29,12 +29,12 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "boiler-config-webpack": "^3.0.9",
     "boiler-utils": "^3.0.9",
-    "browser-sync": "^2.11.1",
+    "browser-sync": "^2.14.0",
     "istanbul-cobertura-badger": "^1.2.1",
     "karma": "^0.13.21",
     "karma-browserstack-launcher": "^0.1.9",
     "karma-chrome-launcher": "^0.2.0",
-    "karma-coverage": "^0.5.3",
+    "karma-coverage": "^0.5.5",
     "karma-firefox-launcher": "^0.1.7",
     "karma-mocha": "^0.2.0",
     "karma-safari-launcher": "^0.1.1",
@@ -43,7 +43,14 @@
     "karma-spec-reporter": "0.0.24",
     "karma-webpack": "^1.5.1",
     "lodash": "^4.0.0",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.3"
-  }
+    "mocha": "^3.0.0",
+    "sinon": "^1.17.3",
+    "snyk": "^1.18.0"
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-task-mocha/.snyk
+++ b/packages/boiler-task-mocha/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-task-mocha/package.json
+++ b/packages/boiler-task-mocha/package.json
@@ -31,7 +31,13 @@
     "babel-polyfill": "^6.3.14",
     "babel-register": "^6.3.13",
     "boiler-utils": "^3.0.9",
-    "gulp-mocha": "^2.2.0",
+    "gulp-mocha": "^3.0.0",
     "lodash": "^4.0.0"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/packages/boiler-task-nodemon/.snyk
+++ b/packages/boiler-task-nodemon/.snyk
@@ -1,0 +1,6 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:tough-cookie:20160722':
+    - nodemon > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T16:03:38.685Z'

--- a/packages/boiler-task-nodemon/package.json
+++ b/packages/boiler-task-nodemon/package.json
@@ -32,6 +32,13 @@
     "lodash": "^4.0.0",
     "nodemon": "^1.9.1",
     "open": "0.0.5",
-    "pty.js": "^0.3.1"
-  }
+    "pty.js": "^0.3.1",
+    "snyk": "^1.18.0"
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-task-selenium/.snyk
+++ b/packages/boiler-task-selenium/.snyk
@@ -1,0 +1,16 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:hawk:20160119':
+    - selenium-standalone > request > hawk:
+        patched: '2016-08-15T16:04:44.975Z'
+  'npm:minimatch:20160620':
+    - nightwatch > minimatch:
+        patched: '2016-08-15T16:04:44.975Z'
+    - nightwatch > mocha-nightwatch > glob > minimatch:
+        patched: '2016-08-15T16:04:44.975Z'
+    - wdio-mocha-framework > mocha > glob > minimatch:
+        patched: '2016-08-15T16:04:44.975Z'
+  'npm:request:20160119':
+    - selenium-standalone > request:
+        patched: '2016-08-15T16:04:44.975Z'

--- a/packages/boiler-task-selenium/package.json
+++ b/packages/boiler-task-selenium/package.json
@@ -39,11 +39,18 @@
     "browserstacktunnel-wrapper": "^1.4.2",
     "immutable": "^3.7.6",
     "lodash": "^4.0.0",
-    "mocha": "^2.4.5",
+    "mocha": "^3.0.0",
     "nightwatch": "^0.9.1",
     "require-hacker": "^2.1.3",
     "selenium-standalone": "5.1.0",
     "wdio-mocha-framework": "^0.2.12",
-    "webdriverio": "^4.0.5"
-  }
+    "webdriverio": "^4.2.4",
+    "snyk": "^1.18.0"
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-task-webpack/.snyk
+++ b/packages/boiler-task-webpack/.snyk
@@ -1,0 +1,53 @@
+version: v1.5.2
+ignore: {}
+patch:
+  'npm:minimatch:20160620':
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > tar > fstream > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - chokidar > fsevents > node-pre-gyp > rimraf > glob > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+    - chokidar > fsevents > node-pre-gyp > tar-pack > fstream-ignore > minimatch:
+        patched: '2016-08-15T16:05:53.128Z'
+  'npm:tough-cookie:20160722':
+    - webpack > watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T16:05:53.128Z'
+    - chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T16:05:53.128Z'
+    - watchpack > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        patched: '2016-08-15T16:05:53.128Z'

--- a/packages/boiler-task-webpack/package.json
+++ b/packages/boiler-task-webpack/package.json
@@ -35,9 +35,16 @@
     "globby": "^4.0.0",
     "lodash": "^4.0.0",
     "webpack-dev-middleware": "^1.5.1",
-    "webpack-hot-middleware": "2.7.1"
+    "webpack-hot-middleware": "2.7.1",
+    "snyk": "^1.18.0"
   },
   "peerDependencies": {
     "webpack": "1.x"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
+  },
+  "snyk": true
 }

--- a/packages/boiler-utils/.snyk
+++ b/packages/boiler-utils/.snyk
@@ -1,0 +1,3 @@
+version: v1.5.2
+ignore: {}
+patch: {}

--- a/packages/boiler-utils/package.json
+++ b/packages/boiler-utils/package.json
@@ -40,5 +40,11 @@
     "require-hacker": "^2.1.3",
     "undertaker-registry": "^1.0.0",
     "yargs": "^4.1.0"
+  },
+  "scripts": {
+    "test": "snyk test"
+  },
+  "devDependencies": {
+    "snyk": "^1.18.0"
   }
 }

--- a/run-snyk.sh
+++ b/run-snyk.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [[ "$#" != 1 || $1 != "wizard" && $1 != "test" ]]
+then
+    echo "Usage: ./run-snyk.sh (wizard|test)"
+    exit 0
+fi
+
+for directory in packages/*
+do
+    (echo "Checking vulnerabilities in $directory" && cd $directory && snyk $1)
+done


### PR DESCRIPTION
@dtothefp Care to take a look?

This just adds Snyk to our dependencies and adds a couple of hooks determine whether or not new dependencies are found.  This is intended to be a really rudimentary introduction of the service, and we can build on this if we decide to incorporate other features.

I've added a script to walk through packages:
- `./run-snyk.sh test` to just list any known vulnerabilities
- `./run-snyk.sh wizard` to open an interactive session for each to patch or upgrade dependencies as vulnerabilities
The former is run as a non-failing check in Travis: https://travis-ci.org/dtothefp/build-boiler#L2740