### PR TITLE
make get_asset tag work for page bundle subresource integrity

### DIFF
--- a/gulp/tasks/eslint.js
+++ b/gulp/tasks/eslint.js
@@ -11,6 +11,9 @@ export default function(gulp, plugins, config, opts) {
     ]);
   } else if (taskName === 'test') {
     data.rules['no-console'] = 0;
+    src.push(
+      addbase('packages/*/test/**/*.js')
+    );
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-preset-stage-0": "^6.1.18",
     "babel-register": "^6.3.13",
     "chai": "^3.5.0",
+    "cheerio": "^0.20.0",
     "debug": "^2.2.0",
     "deps": "^0.1.2",
     "eslint": "^1.10.3",

--- a/packages/boiler-addon-assemble-nunjucks/src/tags/get-asset.js
+++ b/packages/boiler-addon-assemble-nunjucks/src/tags/get-asset.js
@@ -82,11 +82,11 @@ export default class GetAsset {
     if (this.integrity) {
       const re = /<((script|link).+?)>/;
       const split = fp.split(path.sep).filter(dir => !!dir);
-      const len = split.length;
-      const src = len >= 2 ? split.slice(len - 2) : split;
+      const typeI = split.indexOf(this.type);
+      const src = typeI !== -1 ? split.slice(typeI) : split;
       const hash =
-        this.integrity[removeEndSlashes(fp)] ||
-        this.integrity[src.join(path.sep)];
+        this.integrity[removeEndSlashes(fp)] || //remove preceding slash to match keys in 'subresource-integrity-*.json'
+        this.integrity[src.join(path.sep)]; //case for '{css,js}/{**/,}<filename>-<hash>.{css,js}'
       const attrs = [
         `integrity="${hash}"`
       ];
@@ -133,6 +133,8 @@ export default class GetAsset {
         this.cors = 'anonymous';
       }
     }
+
+    this.type = type; //used in the `addIntegrity` method
 
     switch (type) {
       case 'pantsuit':

--- a/packages/boiler-addon-assemble-nunjucks/test/config/nunjucks-tag-setup.js
+++ b/packages/boiler-addon-assemble-nunjucks/test/config/nunjucks-tag-setup.js
@@ -1,0 +1,84 @@
+/*eslint space-after-keywords:0,guard-for-in:0,no-else-return:0,brace-style:0*/
+
+/**
+ * Taken from: https://github.com/mozilla/nunjucks/blob/master/tests/util.js
+ * test examples for tags at: https://github.com/mozilla/nunjucks/blob/master/tests/compiler.j://github.com/mozilla/nunjucks/blob/master/tests/compiler.js
+ */
+import {cbToProm as promisify} from 'boiler-utils';
+import {Environment, Template} from 'nunjucks/src/environment';
+import {FileSystemLoader as Loader} from 'nunjucks/src/node-loaders';
+import cloneDeep from 'lodash/cloneDeep';
+
+const templatesPath = 'tests/templates';
+
+function normEOL(str) {
+  if (!str) return str;
+
+  return str.replace(/\r\n|\r/g, '\n');
+}
+
+function render(str, ctx, opts, env, cb) {
+  if(typeof ctx === 'function') {
+    cb = ctx;
+    ctx = null;
+    opts = null;
+    env = null;
+  }
+  else if(typeof opts === 'function') {
+    cb = opts;
+    opts = null;
+    env = null;
+  }
+  else if(typeof env === 'function') {
+    cb = env;
+    env = null;
+  }
+
+  opts = cloneDeep(opts || {});
+  opts.dev = true;
+  const e = env || new Environment(new Loader(templatesPath), opts);
+  let name;
+
+  if(opts.filters) {
+    for(name in opts.filters) {
+      e.addFilter(name, opts.filters[name]);
+    }
+  }
+
+  if(opts.asyncFilters) {
+    for(name in opts.asyncFilters) {
+      e.addFilter(name, opts.asyncFilters[name], true);
+    }
+  }
+
+  if(opts.extensions) {
+    for(name in opts.extensions) {
+      e.addExtension(name, opts.extensions[name]);
+    }
+  }
+
+  if(opts.globals) {
+    for(name in opts.globals) {
+      e.addGlobal(name, opts.globals[name]);
+    }
+  }
+
+  ctx = ctx || {};
+
+  const t = new Template(str, e);
+
+  if(!cb) {
+    return t.render(ctx);
+  }
+  else {
+    t.render(ctx, function(err, res) {
+      if(err && !opts.noThrow) {
+        cb(err);
+      }
+
+      cb(err, normEOL(res));
+    });
+  }
+}
+
+export default promisify(render);

--- a/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/subresource-integrity-global.json
+++ b/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/subresource-integrity-global.json
@@ -1,0 +1,4 @@
+{
+  "js/global-dc519ee4fc295f8c5940.js": "sha512-N/tBkDb/Sfz1U2GWJh48peIGypiMqj/4xxzmlr/oEfEDpVDN88VmOHfm15fixTaYsOTE8WHNuvnPGYvG+Xhj7g==",
+  "css/global-dc519ee4fc295f8c5940.css": "sha512-jR0ng7qxPegmLXX09iiBv6WViMiNKnxtdUewEakxqSisRnRh/xAGrtF59s4imYStCROL8XZe4vGDkaylzjwmhg=="
+}

--- a/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/subresource-integrity-main.json
+++ b/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/subresource-integrity-main.json
@@ -1,0 +1,13 @@
+{
+  "js/vendors-f54eef436c462bfe6eaf.js": "sha512-iYbCd6bfkEsJtyz+YVhhJtvAcTo3yJMn+cHtJFHtD7xN1SmO3O6Lv+Hn2YZCOxYbhKb8dYaloHr/n4PQ9j7ogw==",
+  "js/article/main-b9a13fe31aa47a4a71be.js": "sha512-iIDb/A0VZ1CSmV4NPn6ZPP6Xlf2PqbQgBkiwtrNNOfV1FfYTwUO40aT2l623+rzA5UnTuddVF7grFuuFt/J4Mw==",
+  "js/basic/main-2f2aea9baae2170a005c.js": "sha512-yRSjvbe30I+d+ivv6qAKXrxyHyu4cZgdn2K5kdfHaAFCJwP9erHB0nM51nEYi//PgBj+yud/3ZAcW0q6hrJk2Q==",
+  "js/login/main-e410cf5777f51744a026.js": "sha512-hg0E0bl6pc9Imm4mlSIi+zuaVeSKzZu1xiprtHJGU1LnMwrKHpnaQk7e9jVDVXlaTfN0vNjkdTxFGNceUDZ5UA==",
+  "js/pages/main-cbf1eb6962fdbbf0d908.js": "sha512-mCXtPGPH2NCFtX0ayAVh5vmfL3P8QgKN4nsfC3DaxqL7tXefx9ICfsvqGqGSLhE69Lkn7s38K0+xM/zF1zPPpw==",
+  "js/states/main-c12997f41c82ceb065db.js": "sha512-7ZbJjRUtFkAbuBNh2WTvP/VxAaB+/1j5s25jTIvXLg8naqoCTcpz7SwX5Xt48F4BCxRLtq/d4Gi+G/I4QaL6gA==",
+  "js/blog/main-4327198ef1ba9858b810.js": "sha512-9+fqxKvcl3Uc37/0d6c8yAtddTm2p1jgLL47mNj23FUMEDHyg9Xo/3PbX6VLa8TJhBaQ+lGmPMIDsw0tjdOHzQ==",
+  "js/unsubscribe/main-cb815db7093c5d3cb0ac.js": "sha512-Tx18O4YIKhkrO7WG9szpHSHxhjtO/4Zas4psIFH8nLbWhXJHljLFFebR8tY2i93UMddCpP9a17I4/AMjjLzvtg==",
+  "js/issues/main-9485b365b9f043187201.js": "sha512-Fc2eUNcLGZB3a6GTwmVNXfphtZ4OTTdm0l9DoEtjHQ81QVtpsDx3xfH3EF1GuVKTOsGG8L5k1k5tTpEDpgcGEQ==",
+  "js/health/main-3094b60169bb0d2a8c85.js": "sha512-HzYG9A8wkwSZdx3Jy3g675UpEVLO4q9xG2Fv/vA3EIBI8zB0BWRPLtqrzeEH+xvVaGYKq78r3T8mE5fAHKHCgw==",
+  "js/about/main-28e6677ff387932da914.js": "sha512-Dmi3FY4VnCHHlUggfAdgrAxu1siWXttjzzSKI2fjo8QhDV4Us1fEd0/pou5BkbGtxaczbLnb6Q71tQbDlBlPVA=="
+}

--- a/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/webpack-global-stats.json
+++ b/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/webpack-global-stats.json
@@ -1,0 +1,15 @@
+{
+  "javascript":{
+    "global":"/js/global-dc519ee4fc295f8c5940.js"
+  },
+  "styles":{
+    "global":"/css/global-dc519ee4fc295f8c5940.css"
+  },
+  "assets":{
+    "favicon.png":"/brand/favicon.png",
+    "mark-h-white.png":"/brand/mark-h-white.png",
+    "mark-h-white.svg":"/brand/mark-h-white.svg",
+    "mark-h.png":"/brand/mark-h.png",
+    "mark-h.svg":"/brand/mark-h.svg"
+  }
+}

--- a/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/webpack-main-stats.json
+++ b/packages/boiler-addon-assemble-nunjucks/test/mocks/webpack-stats/webpack-main-stats.json
@@ -1,0 +1,19 @@
+{
+  "javascript":{
+    "vendors":"/js/vendors-f54eef436c462bfe6eaf.js",
+    "article/main":"/js/article/main-b9a13fe31aa47a4a71be.js",
+    "basic/main":"/js/basic/main-2f2aea9baae2170a005c.js",
+    "login/main":"/js/login/main-e410cf5777f51744a026.js",
+    "pages/main":"/js/pages/main-cbf1eb6962fdbbf0d908.js",
+    "states/main":"/js/states/main-c12997f41c82ceb065db.js",
+    "blog/main":"/js/blog/main-4327198ef1ba9858b810.js",
+    "unsubscribe/main":"/js/unsubscribe/main-cb815db7093c5d3cb0ac.js",
+    "issues/main":"/js/issues/main-9485b365b9f043187201.js",
+    "health/main":"/js/health/main-3094b60169bb0d2a8c85.js",
+    "about/main":"/js/about/main-28e6677ff387932da914.js"
+  },
+  "styles":{},
+  "assets":{
+    "./brand/mark-h.svg":"/brand/mark-h.svg"
+  }
+}

--- a/packages/boiler-addon-assemble-nunjucks/test/tags/get-asset-spec.js
+++ b/packages/boiler-addon-assemble-nunjucks/test/tags/get-asset-spec.js
@@ -1,0 +1,84 @@
+import {expect} from 'chai';
+import path from 'path';
+import cheerio from 'cheerio';
+import {removeEndSlashes} from 'boiler-utils';
+import render from '../config/nunjucks-tag-setup';
+import GetAsset from '../../src/tags/get-asset';
+import makeConfig from '../../../../test/config/make-mock-config';
+import getStats from '../../../boiler-config-assemble/src/parse-assets';
+
+describe('Nunjucks Tag {% get_asset %}', () => {
+  const extensions = {
+    getAsset: new GetAsset()
+  };
+  const opts = {
+    extensions
+  };
+  const sources = {
+    statsDir: path.resolve(__dirname, '..', 'mocks', 'webpack-stats').replace(process.cwd(), '')
+  };
+  const environment = {
+    isDev: false
+  };
+  const config = makeConfig({sources, environment});
+  const {srcDir, templateDir} = config.sources;
+  const view = {
+    path: config.utils.addbase(srcDir, templateDir, 'pages', 'index.html')
+  };
+  const ctx = {
+    environment: config.environment,
+    sources: config.sources,
+    view
+  };
+  let mainCss, vendorsJs, pageJs, assets;
+
+  before(async () => {
+    assets = await getStats(config);
+
+    Object.assign(ctx, {assets});
+
+    vendorsJs = assets.javascript.vendors;
+    pageJs = assets.javascript['pages/main'];
+    mainCss = assets.styles.global;
+  });
+
+  it('should work for subresource integrity for CSS', async () => {
+    const tag = await render(
+      `{% get_asset type="css",integrity=true %}`,
+      ctx,
+      opts
+    );
+    const $ = cheerio.load(tag);
+    const links = $('link').toArray();
+    const [link] = links;
+    const {attribs} = link;
+
+    expect(links.length).to.equal(1);
+    expect(attribs).to.have.all.keys(['href', 'rel', 'integrity', 'crossorigin']);
+
+    expect(attribs.href).to.equal(mainCss);
+    expect(attribs.integrity).to.equal(assets.integrity[removeEndSlashes(mainCss)]);
+  });
+
+  it('should work for subresource integrity for JS', async () => {
+    const tag = await render(
+      `{% get_asset type="js",integrity=true %}`,
+      ctx,
+      opts
+    );
+
+    const $ = cheerio.load(tag);
+    const scripts = $('script').toArray();
+    const [vendorScript, pageScript] = scripts;
+
+    expect(scripts.length).to.equal(2);
+    expect(vendorScript.attribs).to.have.all.keys(['src', 'type', 'integrity', 'crossorigin']);
+    expect(pageScript.attribs).to.have.all.keys(['src', 'type', 'integrity', 'crossorigin']);
+
+    expect(vendorScript.attribs.src).to.equal(vendorsJs);
+    expect(vendorScript.attribs.integrity).to.equal(assets.integrity[removeEndSlashes(vendorsJs)]);
+
+    expect(pageScript.attribs.src).to.equal(pageJs);
+    expect(pageScript.attribs.integrity).to.equal(assets.integrity[removeEndSlashes(pageJs)]);
+  });
+});

--- a/packages/boiler-addon-webpack-isomorphic/test/gather-commonjs-modules-spec.js
+++ b/packages/boiler-addon-webpack-isomorphic/test/gather-commonjs-modules-spec.js
@@ -19,13 +19,13 @@ describe('#gatherCommonjsModules', () => {
       //}
 
       return fp;
-    }
+    };
 
     gatherMod.__set__('require', mock);
   });
 
   after(() => {
-    gatherMod.__set__('require', oldRequire)
+    gatherMod.__set__('require', oldRequire);
     require.resolve = oldRequire;
   });
 
@@ -63,7 +63,7 @@ describe('#gatherCommonjsModules', () => {
       'gulp-newer': '^1.1.0',
       'gulp-plumber': '^1.1.0',
       'gulp-util': '^3.0.7',
-      'gutil': '^1.6.4',
+      'gutil': '^1.6.4'
     }
   };
   const {dependencies} = pkg;
@@ -106,4 +106,4 @@ describe('#gatherCommonjsModules', () => {
 
     expect(externals).to.have.all.keys(filteredKeys);
   });
-})
+});

--- a/packages/boiler-config-assemble/test/utils/template-fns-spec.js
+++ b/packages/boiler-config-assemble/test/utils/template-fns-spec.js
@@ -66,7 +66,7 @@ describe('#templateFns', () => {
       let fp2;
 
       expect(join.bind(null, fp1, fp2)).to.throw(Error);
-    })
+    });
   });
 
   describe('with a branch', () => {

--- a/packages/boiler-task-selenium/test/get-capabilities-spec.js
+++ b/packages/boiler-task-selenium/test/get-capabilities-spec.js
@@ -82,18 +82,20 @@ describe(`#getCapabilities()`, () => {
     });
   });
 
-  const mobileVariations = [{
-    browserName: 'iPhone6S',
-    platform: 'MAC',
-    device: 'iPhone 6S',
-    browser_version: '9.3'
-  },
-  {
-    browserName: 'android',
-    platform: 'ANDROID',
-    device: 'Samsung Galaxy S5',
-    browser_version: '4.4'
-  }];
+  const mobileVariations = [
+    {
+      browserName: 'iPhone6S',
+      platform: 'MAC',
+      device: 'iPhone 6S',
+      browser_version: '9.3'
+    },
+    {
+      browserName: 'android',
+      platform: 'ANDROID',
+      device: 'Samsung Galaxy S5',
+      browser_version: '4.4'
+    }
+  ];
   const mobileCaps = reduce(mobileVariations, (acc, obj) => {
     acc.push({
       'browserstack.debug': 'true',
@@ -194,7 +196,7 @@ describe(`#getCapabilities()`, () => {
       },
       environment: {
         branch
-      },
+      }
     });
     const config = makeMockConfig({ desktop: ['chrome'] });
 

--- a/packages/boiler-task-selenium/test/get-test-files-spec.js
+++ b/packages/boiler-task-selenium/test/get-test-files-spec.js
@@ -58,7 +58,7 @@ describe(`#getTestFiles`, () => {
   ];
   const desktopTests = generalTests.concat([
     'test/e2e/wdio/desktop/some-desktop-spec.js',
-    'test/e2e/wdio/desktop/wait-desktop-spec.js',
+    'test/e2e/wdio/desktop/wait-desktop-spec.js'
   ]).sort();
   const mobileTests = generalTests.concat([
     'test/e2e/wdio/mobile/some-mobile-spec.js'
@@ -98,7 +98,7 @@ describe(`#getTestFiles`, () => {
     const config = makeMockConfig({desktop: ['safari', 'ie']});
     const suite = getTestFiles(config, runnerOptions);
     compareMaps(suite, new Map([
-      [['safari', 'ie'], getTests(desktopTests, tunnelTests)],
+      [['safari', 'ie'], getTests(desktopTests, tunnelTests)]
     ]));
   });
 

--- a/packages/boiler-utils/test/run-parent-fn-spec.js
+++ b/packages/boiler-utils/test/run-parent-fn-spec.js
@@ -36,7 +36,7 @@ describe('#runParentFn()', () => {
       const newSrc = '/bloop.js';
       const opts = {
         fn(gulp, plugins, config, {src, data}) {
-          src.push(newSrc)
+          src.push(newSrc);
 
           return { src, data };
         }
@@ -144,6 +144,3 @@ describe('#runParentFn()', () => {
     });
   });
 });
-
-
-


### PR DESCRIPTION
#### Description
For `multipleBundles` option with Webpack, the page level bundle was not getting subresource integrity attributes added.

![screen shot 2016-08-22 at 5 32 38 pm](https://cloud.githubusercontent.com/assets/4656726/17872515/75c819e2-688e-11e6-9729-e7fb909d29fd.png)

Additionally, added test config and a couple tests for nunjucks tags. I could do a lot more tests but right now was just testing the subresource integrity feature.  

Also, added linting for tests so sorry that the diff is larger than need be.

#### To Test
- `gulp mocha -f get-asset-spec`
- `gulp build && gulp browser-sync`
- "view page source" and see that CSS and JS bundles get subresource integrity added properly

![screen shot 2016-08-22 at 5 31 48 pm](https://cloud.githubusercontent.com/assets/4656726/17872497/5685bc74-688e-11e6-8546-9f25e26b4ec7.png)

![screen shot 2016-08-22 at 5 32 11 pm](https://cloud.githubusercontent.com/assets/4656726/17872505/630f714c-688e-11e6-92aa-a37a22ae50d9.png)
